### PR TITLE
Add configurable prompt suggestions

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -4,3 +4,7 @@ OpenAI Codex userscript
 OpenAI Codex UI Enhancer
 
 **[[INSTALL USERSCRIPT]](https://github.com/supermarsx/openai-codex-userscript/raw/refs/heads/main/openai-codex.user.js)**
+
+The dropdown suggestions can be customised by clicking the gear icon next to the
+dropdown. The list is stored in your browser's `localStorage` so your changes
+persist across sessions.


### PR DESCRIPTION
## Summary
- load saved suggestions from `localStorage` with `loadSuggestions`
- allow editing suggestions through a small UI and persist with `saveSuggestions`
- show gear button to open prompt editor
- document how to customise suggestions

## Testing
- `npm test` *(fails: ENOENT no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686d452567dc8325a573313edc30bc4e