### PR TITLE
Pin shadcn-ui CSS with SRI

### DIFF
--- a/openai-codex.user.js
+++ b/openai-codex.user.js
@@ -11,7 +11,9 @@
     'use strict';
     const cssLink = document.createElement('link');
     cssLink.rel = 'stylesheet';
-    cssLink.href = 'https://unpkg.com/shadcn-ui/dist/index.css';
+    cssLink.href = 'https://unpkg.com/shadcn-ui@0.9.5/dist/index.css';
+    cssLink.integrity = 'sha384-OzJrouefxdP3Nw7TAHTVn7mydEwLPgjLPgFZITrsDNumVhfB3NMgE4o7GP4OU9JP';
+    cssLink.crossOrigin = 'anonymous';
     document.head.appendChild(cssLink);
 
     const style = document.createElement('style');


### PR DESCRIPTION
## Summary
- pin `shadcn-ui` CSS link to version 0.9.5
- add `integrity` and `crossOrigin` attributes

## Testing
- `node -c openai-codex.user.js`
- `apt-get update`
- `apt-get install -y xxd`

------
https://chatgpt.com/codex/tasks/task_e_686ef5c5015083259ace10b6c7ea8baa