### PR TITLE
Fix suggestion insertion for textareas

### DIFF
--- a/openai-codex.user.js
+++ b/openai-codex.user.js
@@ -143,15 +143,21 @@
             if (!value) return;
 
             promptDiv.focus();
-            promptDiv.textContent = '';
-            promptDiv.textContent = value;
 
-            const range = document.createRange();
-            range.selectNodeContents(promptDiv);
-            range.collapse(false);
-            const sel = window.getSelection();
-            sel.removeAllRanges();
-            sel.addRange(range);
+            if (promptDiv instanceof HTMLTextAreaElement) {
+                promptDiv.value = value;
+                promptDiv.setSelectionRange(value.length, value.length);
+            } else {
+                promptDiv.textContent = '';
+                promptDiv.textContent = value;
+
+                const range = document.createRange();
+                range.selectNodeContents(promptDiv);
+                range.collapse(false);
+                const sel = window.getSelection();
+                sel.removeAllRanges();
+                sel.addRange(range);
+            }
 
             dropdown.selectedIndex = 0;
         });

--- a/test.js
+++ b/test.js
@@ -1,0 +1,24 @@
+const { JSDOM } = require('jsdom');
+const fs = require('fs');
+const script = fs.readFileSync('./openai-codex.user.js', 'utf8');
+
+async function runTest(html) {
+  const dom = new JSDOM(html, { runScripts: 'dangerously', resources: 'usable' });
+  dom.window.eval(script);
+  await new Promise(r => dom.window.setTimeout(r, 0));
+  const dropdown = dom.window.document.getElementById('gpt-prompt-suggest-dropdown');
+  const firstOption = dropdown.options[1].value;
+  dropdown.value = firstOption;
+  dropdown.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
+  return dom.window;
+}
+
+(async () => {
+  const textareaHtml = `<div class="flex-col items-center"><textarea id="prompt-textarea"></textarea></div>`;
+  const w1 = await runTest(textareaHtml);
+  console.log('Textarea result:', w1.document.getElementById('prompt-textarea').value);
+
+  const divHtml = `<div class="flex-col items-center"><div id="prompt-textarea" contenteditable="true"></div></div>`;
+  const w2 = await runTest(divHtml);
+  console.log('Contenteditable result:', w2.document.getElementById('prompt-textarea').textContent);
+})();


### PR DESCRIPTION
## Summary
- support both `<textarea>` and contenteditable elements when inserting prompt suggestions
- add a small jsdom-based test script to confirm dropdown behaviour

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_686ef933b8408325881864c6a125db3f