### PR TITLE
Update docs for suggestion editing and dark mode

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -8,8 +8,17 @@ OpenAI Codex UI Enhancer
 This script loads a small CSS theme from `shadcn.css` in this repository. If you host the script yourself, ensure that file is available at the same path.
 
 The dropdown suggestions can be customised by clicking the gear icon next to the
-dropdown. The list is stored in your browser's `localStorage` so your changes
-persist across sessions.
+list. A prompt will let you edit one suggestion per line. The updated entries are
+saved under the `gpt-prompt-suggestions` key in your browser's
+`localStorage`, so your changes persist across sessions.
+
+## Dark mode styling
+
+A lightweight stylesheet (`shadcn.css`) controls the look of the dropdown.
+Theme variables for light and dark mode are injected so the interface adapts to
+your system preference. The stylesheet is loaded with `crossOrigin="anonymous"`
+and its `error` event acts as a basic integrity check; if loading fails a
+minimal fallback style defined in the script is used instead.
 
 The script locates the ChatGPT prompt input using a set of fallback selectors:
 1. `#prompt-textarea`


### PR DESCRIPTION
## Summary
- clarify how to edit suggestion list via the gear icon
- document settings persistence in localStorage
- add section on new dark mode styling and CSS integrity check

## Testing
- `node test.js` *(fails to download CSS due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_686efc0a42e083258d7513787e88a5d2