### PR TITLE
Fix openConfig cleanup

### DIFF
--- a/openai-codex.user.js
+++ b/openai-codex.user.js
@@ -94,7 +94,7 @@
         saveSuggestions(suggestions);
         const existing = document.getElementById('gpt-prompt-suggest-dropdown');
         if (existing) {
-            existing.parentElement.remove();
+            existing.closest('.grid')?.remove();
         }
         injectDropdown(promptDiv, colDiv);
     }

--- a/test.js
+++ b/test.js
@@ -2,11 +2,19 @@ const { JSDOM } = require('jsdom');
 const fs = require('fs');
 const script = fs.readFileSync('./openai-codex.user.js', 'utf8');
 
-async function runTest(html) {
+async function runTest(html, edits = 0) {
   const dom = new JSDOM(html, { runScripts: 'dangerously', resources: 'usable' });
+  dom.window.prompt = () => 'Test suggestion';
   dom.window.eval(script);
   await new Promise(r => dom.window.setTimeout(r, 0));
   const dropdown = dom.window.document.getElementById('gpt-prompt-suggest-dropdown');
+  if (edits > 0) {
+    const configBtn = dropdown.closest('.grid').querySelector('button');
+    for (let i = 0; i < edits; i++) {
+      configBtn.dispatchEvent(new dom.window.Event('click', { bubbles: true }));
+      await new Promise(r => dom.window.setTimeout(r, 0));
+    }
+  }
   const firstOption = dropdown.options[1].value;
   dropdown.value = firstOption;
   dropdown.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
@@ -15,10 +23,12 @@ async function runTest(html) {
 
 (async () => {
   const textareaHtml = `<div class="flex-col items-center"><textarea id="prompt-textarea"></textarea></div>`;
-  const w1 = await runTest(textareaHtml);
+  const w1 = await runTest(textareaHtml, 3);
+  console.log('Textarea wrappers:', w1.document.querySelectorAll('.grid.w-full.gap-1\\.5').length);
   console.log('Textarea result:', w1.document.getElementById('prompt-textarea').value);
 
   const divHtml = `<div class="flex-col items-center"><div id="prompt-textarea" contenteditable="true"></div></div>`;
-  const w2 = await runTest(divHtml);
+  const w2 = await runTest(divHtml, 2);
+  console.log('Contenteditable wrappers:', w2.document.querySelectorAll('.grid.w-full.gap-1\\.5').length);
   console.log('Contenteditable result:', w2.document.getElementById('prompt-textarea').textContent);
 })();


### PR DESCRIPTION
## Summary
- remove entire dropdown wrapper when editing config to avoid orphan grid divs
- verify repeated edits don't leave empty elements

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_686f260447d8832583abe85cc24fafbb