### PR TITLE
Ensure prompt suggestion triggers input events

### DIFF
--- a/openai-codex.user.js
+++ b/openai-codex.user.js
@@ -175,6 +175,7 @@
                 sel.addRange(range);
             }
 
+            promptDiv.dispatchEvent(new InputEvent('input', { bubbles: true }));
             dropdown.selectedIndex = 0;
         });
     }

--- a/test.js
+++ b/test.js
@@ -6,19 +6,22 @@ async function runTest(html) {
   const dom = new JSDOM(html, { runScripts: 'dangerously', resources: 'usable' });
   dom.window.eval(script);
   await new Promise(r => dom.window.setTimeout(r, 0));
+  const prompt = dom.window.document.getElementById('prompt-textarea');
+  let inputTriggered = false;
+  prompt.addEventListener('input', () => { inputTriggered = true; });
   const dropdown = dom.window.document.getElementById('gpt-prompt-suggest-dropdown');
   const firstOption = dropdown.options[1].value;
   dropdown.value = firstOption;
   dropdown.dispatchEvent(new dom.window.Event('change', { bubbles: true }));
-  return dom.window;
+  return { window: dom.window, inputTriggered };
 }
 
 (async () => {
   const textareaHtml = `<div class="flex-col items-center"><textarea id="prompt-textarea"></textarea></div>`;
-  const w1 = await runTest(textareaHtml);
-  console.log('Textarea result:', w1.document.getElementById('prompt-textarea').value);
+  const res1 = await runTest(textareaHtml);
+  console.log('Textarea result:', res1.window.document.getElementById('prompt-textarea').value, 'input event:', res1.inputTriggered);
 
   const divHtml = `<div class="flex-col items-center"><div id="prompt-textarea" contenteditable="true"></div></div>`;
-  const w2 = await runTest(divHtml);
-  console.log('Contenteditable result:', w2.document.getElementById('prompt-textarea').textContent);
+  const res2 = await runTest(divHtml);
+  console.log('Contenteditable result:', res2.window.document.getElementById('prompt-textarea').textContent, 'input event:', res2.inputTriggered);
 })();


### PR DESCRIPTION
## Summary
- fire an `InputEvent` after inserting a suggestion so ChatGPT UI updates instantly
- extend `test.js` to confirm the new event gets dispatched

## Testing
- `node test.js`

------
https://chatgpt.com/codex/tasks/task_e_686f260d4b088325960c28413e09dbd4