### PR TITLE
Fix missing radius values

### DIFF
--- a/shadcn.css
+++ b/shadcn.css
@@ -285,7 +285,7 @@
 
   --ring: 0 0% 3.9%;
 
-  --radius: ;
+  --radius: 0.5rem;
 }
 
 .dark .theme-neutral {
@@ -541,7 +541,7 @@
 
   --ring: 142.1 76.2% 36.3%;
 
-  --radius: ;
+  --radius: 0.5rem;
 }
 
 .dark .theme-green {
@@ -605,7 +605,7 @@
 
   --ring: 221.2 83.2% 53.3%;
 
-  --radius: ;
+  --radius: 0.5rem;
 }
 
 .dark .theme-blue {
@@ -733,7 +733,7 @@
 
   --ring: 262.1 83.3% 57.8%;
 
-  --radius: ;
+  --radius: 0.5rem;
 }
 
 .dark .theme-violet {


### PR DESCRIPTION
## Summary
- give default values to `--radius` in shadcn.css

## Testing
- `node test.js` *(fails to fetch CSS from GitHub but script runs)*

------
https://chatgpt.com/codex/tasks/task_e_686f260f47448325a4c013ff93b9e4ca