### PR TITLE
Add CI workflow for npm tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,18 @@
+name: Node.js CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+      - run: npm install
+      - run: npm test

--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,7 @@ If the page structure changes, update the `findPromptInput` function in
 ## Running tests
 
 Automated tests run in Node using [jsdom](https://github.com/jsdom/jsdom).
-Install dependencies once and run the test script:
+Install dependencies first to ensure `jsdom` is available, then run the test script:
 
 ```bash
 npm install


### PR DESCRIPTION
## Summary
- add Node.js workflow for CI
- clarify that `npm install` must run before `npm test`

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686fd11bcaf88325ac80ab39a73b889a