### PR TITLE
Inline Codex theme

### DIFF
--- a/openai-codex.user.js
+++ b/openai-codex.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.6
+// @version      1.8
 // @description  Adds a prompt suggestion dropdown above the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        none
@@ -18,11 +18,6 @@
             o.disconnect();
         }
     });
-    const cssLink = document.createElement('link');
-    cssLink.rel = 'stylesheet';
-    cssLink.href = "https://github.com/supermarsx/openai-codex-userscript/raw/refs/heads/main/shadcn.css";
-    cssLink.crossOrigin = 'anonymous';
-    document.head.appendChild(cssLink);
 
     const varStyle = document.createElement('style');
     varStyle.textContent = `
@@ -107,9 +102,7 @@
     color: var(--foreground);
 }
 `;
-    cssLink.addEventListener('error', () => {
-        document.head.appendChild(fallbackStyle);
-    });
+    document.head.appendChild(fallbackStyle);
 
     const DEFAULT_SUGGESTIONS = [
         "Suggest code improvements and bugfixes.",

--- a/readme.md
+++ b/readme.md
@@ -4,7 +4,7 @@ OpenAI Codex Super UI Userscript
 
 **[[INSTALL USERSCRIPT]](https://github.com/supermarsx/openai-codex-userscript/raw/refs/heads/main/openai-codex.user.js)**
 
-This script loads a small CSS theme from `shadcn.css` in this repository. If you host the script yourself, ensure that file is available at the same path.
+This script reuses Codex's own theme variables so no extra network request is needed.
 
 The dropdown suggestions can be customised by clicking the gear icon next to the
 list. A prompt will let you edit one suggestion per line. The updated entries are
@@ -26,12 +26,7 @@ archived.
 
 ## Dark mode styling
 
-A lightweight stylesheet (`shadcn.css`) controls the look of the dropdown.
-Theme variables for light and dark mode are injected so the interface adapts to
-your system preference. The stylesheet is loaded with `crossOrigin="anonymous"`
-and its `error` event acts as a basic integrity check; if loading fails a
-minimal fallback style defined in the script is used instead.
-
+Theme variables for light and dark mode are injected from Codex's own CSS so the interface adapts to your system preference. A minimal fallback style keeps the dropdown readable.
 The script locates the ChatGPT prompt input using a set of fallback selectors:
 1. `#prompt-textarea`
 2. `[data-testid="prompt-textarea"]`


### PR DESCRIPTION
## Summary
- remove shadcn.css rules
- reuse Codex theme variables for dropdown styling

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_686fec263c808325a04d85041b28b9f9