### PR TITLE
Handle lack of localStorage

### DIFF
--- a/openai-codex.user.js
+++ b/openai-codex.user.js
@@ -142,6 +142,9 @@
     }
 
     function loadSuggestions() {
+        if (typeof localStorage === 'undefined') {
+            return DEFAULT_SUGGESTIONS.slice();
+        }
         try {
             const raw = localStorage.getItem('gpt-prompt-suggestions');
             if (raw) {
@@ -157,6 +160,9 @@
     }
 
     function saveSuggestions(list) {
+        if (typeof localStorage === 'undefined') {
+            return;
+        }
         try {
             localStorage.setItem('gpt-prompt-suggestions', JSON.stringify(list));
         } catch (e) {


### PR DESCRIPTION
## Summary
- guard `loadSuggestions` and `saveSuggestions` against missing `localStorage`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_686ff46125288325b89146df2c45cc32