### PR TITLE
Fix jsdom URL for localStorage tests

### DIFF
--- a/test.js
+++ b/test.js
@@ -1,29 +1,12 @@
-const { JSDOM, ResourceLoader } = require('jsdom');
+const { JSDOM } = require('jsdom');
 const fs = require('fs');
 const script = fs.readFileSync('./openai-codex.user.js', 'utf8');
 
-class StubLoader extends ResourceLoader {
-  fetch() {
-    return Promise.resolve(Buffer.from(''));
-  }
-}
-
 function createDom(html) {
   const dom = new JSDOM(html, {
+    url: 'https://chatgpt.com/codex',
     runScripts: 'dangerously',
-    resources: new StubLoader()
-  });
-  const store = {};
-  const localStorageMock = {
-    getItem: key => (key in store ? store[key] : null),
-    setItem: (key, value) => {
-      store[key] = String(value);
-    }
-  };
-  Object.defineProperty(dom.window, 'localStorage', {
-    configurable: true,
-    enumerable: true,
-    value: localStorageMock
+    resources: 'usable'
   });
   dom.window.prompt = () => 'Test suggestion';
   return dom;


### PR DESCRIPTION
## Summary
- configure JSDOM in `test.js` with a real URL and enable usable resources
- remove unnecessary resource loader and custom localStorage stubbing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686ffc63dac08325bcbb71d64784636d