### PR TITLE
Refactor to TypeScript build system

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,4 @@
+# Repo Guidelines
+
+- Run `npm run build` before committing changes. This command must output `openai-codex.user.js` in the repo root.
+- Ensure `npm test` passes.

--- a/build.js
+++ b/build.js
@@ -1,0 +1,16 @@
+const fs = require('fs');
+const path = require('path');
+const esbuild = require('esbuild');
+
+esbuild.buildSync({
+  entryPoints: [path.join(__dirname, 'src', 'index.ts')],
+  bundle: true,
+  format: 'iife',
+  platform: 'browser',
+  target: ['es2017'],
+  outfile: path.join(__dirname, 'dist', 'index.js'),
+});
+
+const header = fs.readFileSync(path.join(__dirname, 'src', 'header.js'), 'utf8');
+const main = fs.readFileSync(path.join(__dirname, 'dist', 'index.js'), 'utf8');
+fs.writeFileSync(path.join(__dirname, 'openai-codex.user.js'), header + '\n' + main);

--- a/dist/helpers/dom.js
+++ b/dist/helpers/dom.js
@@ -1,0 +1,33 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.findPromptInput = findPromptInput;
+exports.setPromptText = setPromptText;
+function findPromptInput() {
+    return (document.querySelector('#prompt-textarea') ||
+        document.querySelector('[data-testid="prompt-textarea"]') ||
+        document.querySelector('.ProseMirror#prompt-textarea') ||
+        document.querySelector('.ProseMirror[data-testid="prompt-textarea"]') ||
+        document.querySelector('.ProseMirror'));
+}
+function setPromptText(el, value) {
+    if (!el)
+        return;
+    value = value || '';
+    el.focus();
+    if (el instanceof HTMLTextAreaElement) {
+        el.value = value;
+        el.setSelectionRange(value.length, value.length);
+    }
+    else {
+        el.textContent = '';
+        el.textContent = value;
+        const range = document.createRange();
+        range.selectNodeContents(el);
+        range.collapse(false);
+        const sel = window.getSelection();
+        if (sel) {
+            sel.removeAllRanges();
+            sel.addRange(range);
+        }
+    }
+}

--- a/dist/helpers/history.js
+++ b/dist/helpers/history.js
@@ -1,0 +1,24 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.loadHistory = loadHistory;
+exports.saveHistory = saveHistory;
+exports.addToHistory = addToHistory;
+const storage_1 = require("../lib/storage");
+const STORAGE_KEY = 'gpt-prompt-history';
+const MAX_HISTORY = 50;
+function loadHistory() {
+    return (0, storage_1.loadJSON)(STORAGE_KEY, []);
+}
+function saveHistory(list) {
+    (0, storage_1.saveJSON)(STORAGE_KEY, list);
+}
+function addToHistory(list, text) {
+    text = text.trim();
+    if (!text)
+        return list;
+    list.unshift(text);
+    if (list.length > MAX_HISTORY)
+        list.length = MAX_HISTORY;
+    saveHistory(list);
+    return list;
+}

--- a/dist/helpers/options.js
+++ b/dist/helpers/options.js
@@ -1,0 +1,27 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.DEFAULT_OPTIONS = void 0;
+exports.loadOptions = loadOptions;
+exports.saveOptions = saveOptions;
+const storage_1 = require("../lib/storage");
+exports.DEFAULT_OPTIONS = {
+    theme: null,
+    hideHeader: false,
+    hideDocs: false,
+    hideLogoText: false,
+    hideLogoImage: false,
+    hideProfile: false,
+    autoCheckUpdates: true,
+};
+const STORAGE_KEY = 'gpt-script-options';
+function loadOptions() {
+    const opts = (0, storage_1.loadJSON)(STORAGE_KEY, exports.DEFAULT_OPTIONS);
+    const anyOpts = opts;
+    if ('dark' in anyOpts && !('theme' in anyOpts)) {
+        anyOpts.theme = anyOpts.dark ? 'dark' : 'light';
+    }
+    return Object.assign(Object.assign({}, exports.DEFAULT_OPTIONS), opts);
+}
+function saveOptions(opts) {
+    (0, storage_1.saveJSON)(STORAGE_KEY, opts);
+}

--- a/dist/helpers/suggestions.js
+++ b/dist/helpers/suggestions.js
@@ -1,0 +1,20 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.DEFAULT_SUGGESTIONS = void 0;
+exports.loadSuggestions = loadSuggestions;
+exports.saveSuggestions = saveSuggestions;
+const storage_1 = require("../lib/storage");
+exports.DEFAULT_SUGGESTIONS = [
+    'Suggest code improvements and bugfixes.',
+    'Suggest test coverage improvement tasks.',
+    'Update documentation according to the current features and functionality.',
+    'Suggest code refactor tasks.',
+    'Refactor this function to use async/await.'
+];
+const STORAGE_KEY = 'gpt-prompt-suggestions';
+function loadSuggestions() {
+    return (0, storage_1.loadJSON)(STORAGE_KEY, exports.DEFAULT_SUGGESTIONS.slice());
+}
+function saveSuggestions(list) {
+    (0, storage_1.saveJSON)(STORAGE_KEY, list);
+}

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,12 +1,3 @@
-// ==UserScript==
-// @name         OpenAI Codex UI Enhancer
-// @namespace    http://tampermonkey.net/
-// @version      1.9
-// @description  Adds a prompt suggestion dropdown above the input in ChatGPT Codex and provides a settings modal
-// @match        https://chatgpt.com/codex*
-// @grant        none
-// ==/UserScript==
-
 (() => {
   var __defProp = Object.defineProperty;
   var __getOwnPropSymbols = Object.getOwnPropertySymbols;

--- a/dist/lib/storage.js
+++ b/dist/lib/storage.js
@@ -1,0 +1,24 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+exports.loadJSON = loadJSON;
+exports.saveJSON = saveJSON;
+function loadJSON(key, fallback) {
+    try {
+        const raw = localStorage.getItem(key);
+        if (raw) {
+            return JSON.parse(raw);
+        }
+    }
+    catch (e) {
+        console.error(`Failed to load ${key}`, e);
+    }
+    return fallback;
+}
+function saveJSON(key, data) {
+    try {
+        localStorage.setItem(key, JSON.stringify(data));
+    }
+    catch (e) {
+        console.error(`Failed to save ${key}`, e);
+    }
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,9 @@
       "name": "openai-codex-userscript",
       "version": "1.0.0",
       "devDependencies": {
-        "jsdom": "^24.0.0"
+        "esbuild": "^0.25.6",
+        "jsdom": "^24.0.0",
+        "typescript": "^5.8.3"
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -136,6 +138,448 @@
         }
       ],
       "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.6.tgz",
+      "integrity": "sha512-ShbM/3XxwuxjFiuVBHA+d3j5dyac0aEVVq1oluIDf71hUw0aRF59dV/efUsIwFnR6m8JNM2FjZOzmaZ8yG61kw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.6.tgz",
+      "integrity": "sha512-S8ToEOVfg++AU/bHwdksHNnyLyVM+eMVAOf6yRKFitnwnbwwPNqKr3srzFRe7nzV69RQKb5DgchIX5pt3L53xg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.6.tgz",
+      "integrity": "sha512-hd5zdUarsK6strW+3Wxi5qWws+rJhCCbMiC9QZyzoxfk5uHRIE8T287giQxzVpEvCwuJ9Qjg6bEjcRJcgfLqoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.6.tgz",
+      "integrity": "sha512-0Z7KpHSr3VBIO9A/1wcT3NTy7EB4oNC4upJ5ye3R7taCc2GUdeynSLArnon5G8scPwaU866d3H4BCrE5xLW25A==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.6.tgz",
+      "integrity": "sha512-FFCssz3XBavjxcFxKsGy2DYK5VSvJqa6y5HXljKzhRZ87LvEi13brPrf/wdyl/BbpbMKJNOr1Sd0jtW4Ge1pAA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.6.tgz",
+      "integrity": "sha512-GfXs5kry/TkGM2vKqK2oyiLFygJRqKVhawu3+DOCk7OxLy/6jYkWXhlHwOoTb0WqGnWGAS7sooxbZowy+pK9Yg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.6.tgz",
+      "integrity": "sha512-aoLF2c3OvDn2XDTRvn8hN6DRzVVpDlj2B/F66clWd/FHLiHaG3aVZjxQX2DYphA5y/evbdGvC6Us13tvyt4pWg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.6.tgz",
+      "integrity": "sha512-2SkqTjTSo2dYi/jzFbU9Plt1vk0+nNg8YC8rOXXea+iA3hfNJWebKYPs3xnOUf9+ZWhKAaxnQNUf2X9LOpeiMQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.6.tgz",
+      "integrity": "sha512-SZHQlzvqv4Du5PrKE2faN0qlbsaW/3QQfUUc6yO2EjFcA83xnwm91UbEEVx4ApZ9Z5oG8Bxz4qPE+HFwtVcfyw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.6.tgz",
+      "integrity": "sha512-b967hU0gqKd9Drsh/UuAm21Khpoh6mPBSgz8mKRq4P5mVK8bpA+hQzmm/ZwGVULSNBzKdZPQBRT3+WuVavcWsQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.6.tgz",
+      "integrity": "sha512-aHWdQ2AAltRkLPOsKdi3xv0mZ8fUGPdlKEjIEhxCPm5yKEThcUjHpWB1idN74lfXGnZ5SULQSgtr5Qos5B0bPw==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.6.tgz",
+      "integrity": "sha512-VgKCsHdXRSQ7E1+QXGdRPlQ/e08bN6WMQb27/TMfV+vPjjTImuT9PmLXupRlC90S1JeNNW5lzkAEO/McKeJ2yg==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.6.tgz",
+      "integrity": "sha512-WViNlpivRKT9/py3kCmkHnn44GkGXVdXfdc4drNmRl15zVQ2+D2uFwdlGh6IuK5AAnGTo2qPB1Djppj+t78rzw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.6.tgz",
+      "integrity": "sha512-wyYKZ9NTdmAMb5730I38lBqVu6cKl4ZfYXIs31Baf8aoOtB4xSGi3THmDYt4BTFHk7/EcVixkOV2uZfwU3Q2Jw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.6.tgz",
+      "integrity": "sha512-KZh7bAGGcrinEj4qzilJ4hqTY3Dg2U82c8bv+e1xqNqZCrCyc+TL9AUEn5WGKDzm3CfC5RODE/qc96OcbIe33w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.6.tgz",
+      "integrity": "sha512-9N1LsTwAuE9oj6lHMyyAM+ucxGiVnEqUdp4v7IaMmrwb06ZTEVCIs3oPPplVsnjPfyjmxwHxHMF8b6vzUVAUGw==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.6.tgz",
+      "integrity": "sha512-A6bJB41b4lKFWRKNrWoP2LHsjVzNiaurf7wyj/XtFNTsnPuxwEBWHLty+ZE0dWBKuSK1fvKgrKaNjBS7qbFKig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.6.tgz",
+      "integrity": "sha512-IjA+DcwoVpjEvyxZddDqBY+uJ2Snc6duLpjmkXm/v4xuS3H+3FkLZlDm9ZsAbF9rsfP3zeA0/ArNDORZgrxR/Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.6.tgz",
+      "integrity": "sha512-dUXuZr5WenIDlMHdMkvDc1FAu4xdWixTCRgP7RQLBOkkGgwuuzaGSYcOpW4jFxzpzL1ejb8yF620UxAqnBrR9g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.6.tgz",
+      "integrity": "sha512-l8ZCvXP0tbTJ3iaqdNf3pjaOSd5ex/e6/omLIQCVBLmHTlfXW3zAxQ4fnDmPLOB1x9xrcSi/xtCWFwCZRIaEwg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.6.tgz",
+      "integrity": "sha512-hKrmDa0aOFOr71KQ/19JC7az1P0GWtCN1t2ahYAf4O007DHZt/dW8ym5+CUdJhQ/qkZmI1HAF8KkJbEFtCL7gw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.6.tgz",
+      "integrity": "sha512-+SqBcAWoB1fYKmpWoQP4pGtx+pUUC//RNYhFdbcSA16617cchuryuhOCRpPsjCblKukAckWsV+aQ3UKT/RMPcA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.6.tgz",
+      "integrity": "sha512-dyCGxv1/Br7MiSC42qinGL8KkG4kX0pEsdb0+TKhmJZgCUDBGmyo1/ArCjNGiOLiIAgdbWgmWgib4HoCi5t7kA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.6.tgz",
+      "integrity": "sha512-42QOgcZeZOvXfsCBJF5Afw73t4veOId//XD3i+/9gSkhSV6Gk3VPlWncctI+JcOyERv85FUo7RxuxGy+z8A43Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.6.tgz",
+      "integrity": "sha512-4AWhgXmDuYN7rJI6ORB+uU9DHLq/erBbuMoAuB4VWJTu5KtCgcKYPynF0YI1VkBNuEfjNlLrFr9KZPJzrtLkrQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.6.tgz",
+      "integrity": "sha512-NgJPHHbEpLQgDH2MjQu90pzW/5vvXIZ7KOnPyNBm92A6WgZ/7b6fJyUBjoumLqeOQQGqY2QjQxRo97ah4Sj0cA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
       "engines": {
         "node": ">=18"
       }
@@ -329,6 +773,48 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.6",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.6.tgz",
+      "integrity": "sha512-GVuzuUwtdsghE3ocJ9Bs8PNoF13HNQ5TXbEi2AhvVb8xU1Iwt9Fos9FEamfoee+u/TOsn7GUWc04lz46n2bbTg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.6",
+        "@esbuild/android-arm": "0.25.6",
+        "@esbuild/android-arm64": "0.25.6",
+        "@esbuild/android-x64": "0.25.6",
+        "@esbuild/darwin-arm64": "0.25.6",
+        "@esbuild/darwin-x64": "0.25.6",
+        "@esbuild/freebsd-arm64": "0.25.6",
+        "@esbuild/freebsd-x64": "0.25.6",
+        "@esbuild/linux-arm": "0.25.6",
+        "@esbuild/linux-arm64": "0.25.6",
+        "@esbuild/linux-ia32": "0.25.6",
+        "@esbuild/linux-loong64": "0.25.6",
+        "@esbuild/linux-mips64el": "0.25.6",
+        "@esbuild/linux-ppc64": "0.25.6",
+        "@esbuild/linux-riscv64": "0.25.6",
+        "@esbuild/linux-s390x": "0.25.6",
+        "@esbuild/linux-x64": "0.25.6",
+        "@esbuild/netbsd-arm64": "0.25.6",
+        "@esbuild/netbsd-x64": "0.25.6",
+        "@esbuild/openbsd-arm64": "0.25.6",
+        "@esbuild/openbsd-x64": "0.25.6",
+        "@esbuild/openharmony-arm64": "0.25.6",
+        "@esbuild/sunos-x64": "0.25.6",
+        "@esbuild/win32-arm64": "0.25.6",
+        "@esbuild/win32-ia32": "0.25.6",
+        "@esbuild/win32-x64": "0.25.6"
       }
     },
     "node_modules/form-data": {
@@ -719,6 +1205,20 @@
       },
       "engines": {
         "node": ">=18"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.8.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.8.3.tgz",
+      "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
       }
     },
     "node_modules/universalify": {

--- a/package.json
+++ b/package.json
@@ -2,9 +2,12 @@
   "name": "openai-codex-userscript",
   "version": "1.0.0",
   "scripts": {
-    "test": "node test.js"
+    "build": "node build.js",
+    "test": "npm run build && node test.js"
   },
   "devDependencies": {
-    "jsdom": "^24.0.0"
+    "esbuild": "^0.25.6",
+    "jsdom": "^24.0.0",
+    "typescript": "^5.8.3"
   }
 }

--- a/readme.md
+++ b/readme.md
@@ -3,6 +3,8 @@
 OpenAI Codex Super UI Userscript
 
 **[[INSTALL USERSCRIPT]](https://github.com/supermarsx/openai-codex-userscript/raw/refs/heads/main/openai-codex.user.js)**
+Install Violentmonkey from https://violentmonkey.github.io/get-it/ to run the userscript.
+
 
 This script reuses Codex's own theme variables so no extra network request is needed.
 

--- a/src/header.js
+++ b/src/header.js
@@ -1,0 +1,8 @@
+// ==UserScript==
+// @name         OpenAI Codex UI Enhancer
+// @namespace    http://tampermonkey.net/
+// @version      1.9
+// @description  Adds a prompt suggestion dropdown above the input in ChatGPT Codex and provides a settings modal
+// @match        https://chatgpt.com/codex*
+// @grant        none
+// ==/UserScript==

--- a/src/helpers/dom.ts
+++ b/src/helpers/dom.ts
@@ -1,0 +1,30 @@
+export function findPromptInput(): HTMLElement | null {
+  return (
+    document.querySelector('#prompt-textarea') ||
+    document.querySelector('[data-testid="prompt-textarea"]') ||
+    document.querySelector('.ProseMirror#prompt-textarea') ||
+    document.querySelector('.ProseMirror[data-testid="prompt-textarea"]') ||
+    document.querySelector('.ProseMirror')
+  ) as HTMLElement | null;
+}
+
+export function setPromptText(el: HTMLElement | null, value: string): void {
+  if (!el) return;
+  value = value || '';
+  el.focus();
+  if (el instanceof HTMLTextAreaElement) {
+    el.value = value;
+    el.setSelectionRange(value.length, value.length);
+  } else {
+    el.textContent = '';
+    el.textContent = value;
+    const range = document.createRange();
+    range.selectNodeContents(el);
+    range.collapse(false);
+    const sel = window.getSelection();
+    if (sel) {
+      sel.removeAllRanges();
+      sel.addRange(range);
+    }
+  }
+}

--- a/src/helpers/history.ts
+++ b/src/helpers/history.ts
@@ -1,0 +1,21 @@
+import { loadJSON, saveJSON } from '../lib/storage';
+
+const STORAGE_KEY = 'gpt-prompt-history';
+const MAX_HISTORY = 50;
+
+export function loadHistory(): string[] {
+  return loadJSON<string[]>(STORAGE_KEY, []);
+}
+
+export function saveHistory(list: string[]): void {
+  saveJSON(STORAGE_KEY, list);
+}
+
+export function addToHistory(list: string[], text: string): string[] {
+  text = text.trim();
+  if (!text) return list;
+  list.unshift(text);
+  if (list.length > MAX_HISTORY) list.length = MAX_HISTORY;
+  saveHistory(list);
+  return list;
+}

--- a/src/helpers/options.ts
+++ b/src/helpers/options.ts
@@ -1,0 +1,36 @@
+import { loadJSON, saveJSON } from '../lib/storage';
+
+export interface Options {
+  theme: string | null;
+  hideHeader: boolean;
+  hideDocs: boolean;
+  hideLogoText: boolean;
+  hideLogoImage: boolean;
+  hideProfile: boolean;
+  autoCheckUpdates: boolean;
+}
+
+export const DEFAULT_OPTIONS: Options = {
+  theme: null,
+  hideHeader: false,
+  hideDocs: false,
+  hideLogoText: false,
+  hideLogoImage: false,
+  hideProfile: false,
+  autoCheckUpdates: true,
+};
+
+const STORAGE_KEY = 'gpt-script-options';
+
+export function loadOptions(): Options {
+  const opts = loadJSON<Options>(STORAGE_KEY, DEFAULT_OPTIONS);
+  const anyOpts: any = opts;
+  if ('dark' in anyOpts && !('theme' in anyOpts)) {
+    anyOpts.theme = anyOpts.dark ? 'dark' : 'light';
+  }
+  return { ...DEFAULT_OPTIONS, ...opts };
+}
+
+export function saveOptions(opts: Options): void {
+  saveJSON(STORAGE_KEY, opts);
+}

--- a/src/helpers/suggestions.ts
+++ b/src/helpers/suggestions.ts
@@ -1,0 +1,19 @@
+import { loadJSON, saveJSON } from '../lib/storage';
+
+export const DEFAULT_SUGGESTIONS = [
+  'Suggest code improvements and bugfixes.',
+  'Suggest test coverage improvement tasks.',
+  'Update documentation according to the current features and functionality.',
+  'Suggest code refactor tasks.',
+  'Refactor this function to use async/await.'
+];
+
+const STORAGE_KEY = 'gpt-prompt-suggestions';
+
+export function loadSuggestions(): string[] {
+  return loadJSON<string[]>(STORAGE_KEY, DEFAULT_SUGGESTIONS.slice());
+}
+
+export function saveSuggestions(list: string[]): void {
+  saveJSON(STORAGE_KEY, list);
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,0 +1,566 @@
+// @ts-nocheck
+import { loadOptions, saveOptions } from "./helpers/options";
+import { loadSuggestions, saveSuggestions, DEFAULT_SUGGESTIONS } from "./helpers/suggestions";
+import { loadHistory, saveHistory, addToHistory } from "./helpers/history";
+import { findPromptInput, setPromptText } from "./helpers/dom";
+(function () {
+
+    'use strict';
+    const SCRIPT_VERSION = '1.9';
+    const observers = [];
+    let promptInputObserver = null;
+    let dropdownObserver = null;
+    let currentPromptDiv = null;
+    let currentColDiv = null;
+
+    window.addEventListener('beforeunload', () => {
+        for (const o of observers) {
+            o.disconnect();
+        }
+    });
+
+    const varStyle = document.createElement('style');
+    varStyle.textContent = `
+:root {
+    --background: #ffffff;
+    --foreground: #18181b;
+    --ring: #d4d4d8;
+}
+@media (prefers-color-scheme: dark) {
+    :root {
+        --background: #40414f;
+        --foreground: #ececf1;
+        --ring: #565869;
+    }
+}
+.userscript-force-light {
+    --background: #ffffff;
+    --foreground: #18181b;
+    --ring: #d4d4d8;
+}
+.userscript-force-dark {
+    --background: #40414f;
+    --foreground: #ececf1;
+    --ring: #565869;
+}
+.userscript-force-oled {
+    --background: #000000;
+    --foreground: #ffffff;
+    --ring: #333333;
+}
+`;
+    document.head.appendChild(varStyle);
+
+    const settingsStyle = document.createElement('style');
+    settingsStyle.textContent = `
+#gpt-settings-gear {
+    position: fixed;
+    top: 50%;
+    right: 8px;
+    z-index: 1000;
+    background: var(--background);
+    color: var(--foreground);
+    border: 1px solid var(--ring);
+    width: 32px;
+    height: 32px;
+    border-radius: 9999px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+}
+#gpt-settings-modal {
+    position: fixed;
+    inset: 0;
+    z-index: 1000;
+    background: rgba(0,0,0,0.5);
+    display: none;
+    align-items: center;
+    justify-content: center;
+}
+#gpt-settings-modal.show { display: flex; }
+#gpt-settings-modal .modal-content {
+    background: var(--background);
+    color: var(--foreground);
+    border: 1px solid var(--ring);
+    border-radius: 0.5rem;
+    padding: 1rem;
+    max-width: 90%;
+    width: 400px;
+}
+#gpt-settings-modal button { border: 1px solid var(--ring); padding: 2px 6px; border-radius: 4px; }
+#gpt-settings-modal ul { list-style: none; padding: 0; margin: 0 0 0.5rem 0; }
+#gpt-settings-modal li { display: flex; justify-content: space-between; align-items: center; margin-bottom: 4px; }
+#gpt-history-modal { position: fixed; inset: 0; z-index: 1000; background: rgba(0,0,0,0.5); display: none; align-items: center; justify-content: center; }
+#gpt-history-modal.show { display: flex; }
+#gpt-history-modal .modal-content { background: var(--background); color: var(--foreground); border: 1px solid var(--ring); border-radius: 0.5rem; padding: 1rem; max-width: 90%; width: 400px; }
+#gpt-history-modal button { border: 1px solid var(--ring); padding: 2px 6px; border-radius: 4px; }
+`;
+    document.head.appendChild(settingsStyle);
+
+    const fallbackStyle = document.createElement('style');
+    fallbackStyle.textContent = `
+#gpt-prompt-suggest-dropdown {
+    background-color: var(--background);
+    color: var(--foreground);
+    border-color: var(--ring);
+}
+#gpt-prompt-suggest-dropdown option {
+    background-color: var(--background);
+    color: var(--foreground);
+}
+`;
+    document.head.appendChild(fallbackStyle);
+    let suggestions = loadSuggestions() || DEFAULT_SUGGESTIONS.slice();
+    let options = loadOptions();
+    let history = loadHistory();
+
+
+
+
+    function toggleHeader(hide) {
+        const node = document.evaluate("//*[contains(text(),'What are we coding next?')]", document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+        if (node) node.style.display = hide ? 'none' : '';
+    }
+
+    function toggleDocs(hide) {
+        const res = document.evaluate("//a[contains(.,'Docs')]", document, null, XPathResult.ORDERED_NODE_ITERATOR_TYPE, null);
+        let el;
+        while ((el = res.iterateNext())) {
+            el.style.display = hide ? 'none' : '';
+        }
+    }
+
+    function toggleLogoText(hide) {
+        const node = document.evaluate("//*[contains(text(),'Codex')]", document, null, XPathResult.FIRST_ORDERED_NODE_TYPE, null).singleNodeValue;
+        if (node) node.style.display = hide ? 'none' : '';
+    }
+
+    function toggleLogoImage(hide) {
+        const img = document.querySelector('img[alt*="Codex" i], svg[aria-label*="Codex" i]');
+        if (img) img.style.display = hide ? 'none' : '';
+    }
+
+    function toggleProfile(hide) {
+        const node = document.querySelector('[aria-label*="Profile" i], [data-testid*="profile" i], [class*="profile" i], [class*="avatar" i]');
+        if (node) node.style.display = hide ? 'none' : '';
+    }
+
+    function applyOptions() {
+        const root = document.documentElement;
+        root.classList.remove('userscript-force-light', 'userscript-force-dark', 'userscript-force-oled');
+        const prefersDark = typeof window.matchMedia === 'function' && window.matchMedia('(prefers-color-scheme: dark)').matches;
+        const theme = options.theme || (prefersDark ? 'dark' : 'light');
+        root.classList.add(`userscript-force-${theme}`);
+        toggleHeader(options.hideHeader);
+        toggleDocs(options.hideDocs);
+        toggleLogoText(options.hideLogoText);
+        toggleLogoImage(options.hideLogoImage);
+        toggleProfile(options.hideProfile);
+    }
+
+    async function checkForUpdates() {
+        if (typeof fetch !== 'function') return;
+        try {
+            const resp = await fetch('https://raw.githubusercontent.com/supermarsx/openai-codex-userscript/main/openai-codex.user.js', { cache: 'no-store' });
+            if (!resp.ok) throw new Error('Network error');
+            const txt = await resp.text();
+            const m = txt.match(/@version\s+(\S+)/);
+            if (m) {
+                const latest = m[1];
+                if (latest !== SCRIPT_VERSION) {
+                    if (window.confirm(`Update available (v${latest}). Open download page?`)) {
+                        window.open('https://github.com/supermarsx/openai-codex-userscript/raw/refs/heads/main/openai-codex.user.js', '_blank');
+                    }
+                } else {
+                    window.alert('No updates found.');
+                }
+            }
+        } catch (e) {
+            console.error('Failed to check for updates', e);
+        }
+    }
+
+    const gear = document.createElement('div');
+    gear.id = 'gpt-settings-gear';
+    gear.textContent = '⚙️';
+    document.body.appendChild(gear);
+
+    const modal = document.createElement('div');
+    modal.id = 'gpt-settings-modal';
+    modal.innerHTML = `
+    <div class="modal-content">
+        <h2 class="mb-2 text-lg">Settings</h2>
+        <div id="gpt-settings-suggestions"></div>
+        <label>Theme:
+            <select id="gpt-setting-theme">
+                <option value="light">Light</option>
+                <option value="dark">Dark</option>
+                <option value="oled">OLED</option>
+            </select>
+        </label><br>
+        <label><input type="checkbox" id="gpt-setting-header"> Hide header</label><br>
+        <label><input type="checkbox" id="gpt-setting-docs"> Hide Docs link</label><br>
+        <label><input type="checkbox" id="gpt-setting-logo-text"> Hide logo text</label><br>
+        <label><input type="checkbox" id="gpt-setting-logo-image"> Hide logo image</label><br>
+        <label><input type="checkbox" id="gpt-setting-profile"> Hide profile icon</label><br>
+        <label><input type="checkbox" id="gpt-setting-auto-updates"> Auto-check for updates</label><br>
+        <button id="gpt-update-check">Check for Updates</button><br>
+        <div class="mt-2 text-right"><button id="gpt-settings-close">Close</button></div>
+    </div>`;
+    document.body.appendChild(modal);
+
+    const historyModal = document.createElement('div');
+    historyModal.id = 'gpt-history-modal';
+    historyModal.innerHTML = `
+    <div class="modal-content">
+        <h2 class="mb-2 text-lg">Prompt History</h2>
+        <div id="gpt-history-list"></div>
+        <div class="mt-2 text-right"><button id="gpt-history-clear">Clear</button> <button id="gpt-history-close">Close</button></div>
+    </div>`;
+    document.body.appendChild(historyModal);
+
+    function refreshDropdown() {
+        if (currentPromptDiv && currentColDiv) {
+            const existing = document.getElementById('gpt-prompt-suggest-dropdown');
+            if (existing) existing.closest('.grid')?.remove();
+            injectDropdown(currentPromptDiv, currentColDiv);
+        }
+    }
+
+    function renderSuggestions() {
+        const wrap = modal.querySelector('#gpt-settings-suggestions');
+        wrap.innerHTML = '<h3 class="mb-1">Prompt Suggestions</h3>';
+        const ul = document.createElement('ul');
+        suggestions.forEach((s, i) => {
+            const li = document.createElement('li');
+            const span = document.createElement('span');
+            span.textContent = s;
+            li.appendChild(span);
+            const edit = document.createElement('button');
+            edit.textContent = 'Edit';
+            const del = document.createElement('button');
+            del.textContent = 'Remove';
+            edit.addEventListener('click', () => {
+                const inp = window.prompt('Edit suggestion:', s);
+                if (inp !== null) {
+                    suggestions[i] = inp.trim();
+                    saveSuggestions(suggestions);
+                    renderSuggestions();
+                    refreshDropdown();
+                }
+            });
+            del.addEventListener('click', () => {
+                suggestions.splice(i, 1);
+                saveSuggestions(suggestions);
+                renderSuggestions();
+                refreshDropdown();
+            });
+            const btnWrap = document.createElement('span');
+            btnWrap.appendChild(edit);
+            btnWrap.appendChild(del);
+            li.appendChild(btnWrap);
+            ul.appendChild(li);
+        });
+        wrap.appendChild(ul);
+        const addBtn = document.createElement('button');
+        addBtn.textContent = 'Add';
+        addBtn.addEventListener('click', () => {
+            const inp = window.prompt('New suggestion:');
+            if (inp) {
+                suggestions.push(inp.trim());
+                saveSuggestions(suggestions);
+                renderSuggestions();
+                refreshDropdown();
+            }
+        });
+        wrap.appendChild(addBtn);
+    }
+
+    function openSettings() {
+        renderSuggestions();
+        const themeSelect = modal.querySelector('#gpt-setting-theme');
+        const prefersDark = typeof window.matchMedia === 'function' && window.matchMedia('(prefers-color-scheme: dark)').matches;
+        const systemTheme = prefersDark ? 'dark' : 'light';
+        themeSelect.value = options.theme || systemTheme;
+        modal.querySelector('#gpt-setting-header').checked = options.hideHeader;
+        modal.querySelector('#gpt-setting-docs').checked = options.hideDocs;
+        modal.querySelector('#gpt-setting-logo-text').checked = options.hideLogoText;
+        modal.querySelector('#gpt-setting-logo-image').checked = options.hideLogoImage;
+        modal.querySelector('#gpt-setting-profile').checked = options.hideProfile;
+        modal.querySelector('#gpt-setting-auto-updates').checked = options.autoCheckUpdates;
+        modal.classList.add('show');
+    }
+
+    function renderHistory() {
+        const wrap = historyModal.querySelector('#gpt-history-list');
+        wrap.innerHTML = '';
+        const ul = document.createElement('ul');
+        history.forEach((h, i) => {
+            const li = document.createElement('li');
+            const span = document.createElement('span');
+            span.textContent = h;
+            li.appendChild(span);
+            const useBtn = document.createElement('button');
+            useBtn.textContent = 'Use';
+            useBtn.addEventListener('click', () => {
+                setPromptText(currentPromptDiv || findPromptInput(), h);
+                historyModal.classList.remove('show');
+            });
+            li.appendChild(useBtn);
+            ul.appendChild(li);
+        });
+        wrap.appendChild(ul);
+    }
+
+    function openHistory() {
+        renderHistory();
+        historyModal.classList.add('show');
+    }
+
+    gear.addEventListener('click', openSettings);
+    modal.querySelector('#gpt-settings-close').addEventListener('click', () => modal.classList.remove('show'));
+    historyModal.querySelector('#gpt-history-close').addEventListener('click', () => historyModal.classList.remove('show'));
+    historyModal.querySelector('#gpt-history-clear').addEventListener('click', () => { history = []; saveHistory(history); renderHistory(); });
+    modal.querySelector('#gpt-setting-theme').addEventListener('change', (e) => { options.theme = e.target.value; saveOptions(options); applyOptions(); });
+    modal.querySelector('#gpt-setting-header').addEventListener('change', (e) => { options.hideHeader = e.target.checked; saveOptions(options); applyOptions(); });
+    modal.querySelector('#gpt-setting-docs').addEventListener('change', (e) => { options.hideDocs = e.target.checked; saveOptions(options); applyOptions(); });
+    modal.querySelector('#gpt-setting-logo-text').addEventListener('change', (e) => { options.hideLogoText = e.target.checked; saveOptions(options); applyOptions(); });
+    modal.querySelector('#gpt-setting-logo-image').addEventListener('change', (e) => { options.hideLogoImage = e.target.checked; saveOptions(options); applyOptions(); });
+    modal.querySelector('#gpt-setting-profile').addEventListener('change', (e) => { options.hideProfile = e.target.checked; saveOptions(options); applyOptions(); });
+    modal.querySelector('#gpt-setting-auto-updates').addEventListener('change', (e) => { options.autoCheckUpdates = e.target.checked; saveOptions(options); });
+    modal.querySelector('#gpt-update-check').addEventListener('click', () => checkForUpdates());
+
+    const pageObserver = new MutationObserver(() => {
+        toggleHeader(options.hideHeader);
+        toggleDocs(options.hideDocs);
+        toggleLogoText(options.hideLogoText);
+        toggleLogoImage(options.hideLogoImage);
+        toggleProfile(options.hideProfile);
+    });
+    observers.push(pageObserver);
+    pageObserver.observe(document.body, { childList: true, subtree: true });
+
+    applyOptions();
+    if (options.autoCheckUpdates) {
+        checkForUpdates();
+    }
+
+    // Automatically archive tasks based on status changes
+    function findArchiveButton() {
+        return (
+            document.querySelector('[data-testid="archive-task"]') ||
+            Array.from(document.querySelectorAll('button')).find(b => /archive/i.test(b.textContent))
+        );
+    }
+
+    function findSendButton() {
+        return (
+            document.querySelector('[data-testid*="send" i]') ||
+            Array.from(document.querySelectorAll('button')).find(b => /send/i.test(b.getAttribute('aria-label') || b.dataset?.testid || b.textContent))
+        );
+    }
+
+    function autoArchiveOnMerged() {
+        const btn = findArchiveButton();
+        if (btn) btn.click();
+    }
+
+    function autoArchiveOnClosed() {
+        const btn = findArchiveButton();
+        if (btn) btn.click();
+    }
+
+    let lastTaskStatus = null;
+
+    function detectTaskStatus() {
+        const el =
+            document.querySelector('[data-testid="task-status"]') ||
+            document.querySelector('.task-status');
+        if (!el) return;
+        const status = el.textContent.trim();
+        if (status && status !== lastTaskStatus) {
+            lastTaskStatus = status;
+            if (/merged/i.test(status)) {
+                autoArchiveOnMerged();
+            } else if (/closed/i.test(status)) {
+                autoArchiveOnClosed();
+            }
+        }
+    }
+
+    const taskObserver = new MutationObserver(detectTaskStatus);
+    observers.push(taskObserver);
+    taskObserver.observe(document.body, { childList: true, subtree: true, characterData: true });
+    detectTaskStatus();
+
+    // Returns the main prompt input using several fallbacks.
+    // 1. Prefer an element with the id "prompt-textarea".
+    // 2. If not found, try the data-testid attribute.
+    // 3. As a final fallback, search for the ProseMirror editor element.
+    function findPromptInput() {
+        return (
+            document.querySelector('#prompt-textarea') ||
+            document.querySelector('[data-testid="prompt-textarea"]') ||
+            document.querySelector('.ProseMirror#prompt-textarea') ||
+            document.querySelector('.ProseMirror[data-testid="prompt-textarea"]') ||
+            document.querySelector('.ProseMirror')
+        );
+    }
+
+    function setPromptText(el, value) {
+        if (!el) return;
+        value = value || '';
+        el.focus();
+        if (el instanceof HTMLTextAreaElement) {
+            el.value = value;
+            el.setSelectionRange(value.length, value.length);
+        } else {
+            el.textContent = '';
+            el.textContent = value;
+            const range = document.createRange();
+            range.selectNodeContents(el);
+            range.collapse(false);
+            const sel = window.getSelection();
+            sel.removeAllRanges();
+            sel.addRange(range);
+        }
+    }
+
+    // Creates and injects the dropdown element
+    function injectDropdown(promptDiv, colDiv) {
+        if (document.getElementById('gpt-prompt-suggest-dropdown')) return;
+
+        const dropdown = document.createElement('select');
+        dropdown.id = 'gpt-prompt-suggest-dropdown';
+        dropdown.className = 'flex h-8 w-full rounded-md border bg-background px-3 py-1 text-sm shadow-sm focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring';
+
+        const defaultOpt = document.createElement('option');
+        defaultOpt.value = '';
+        defaultOpt.innerText = '💡 Insert a prompt suggestion...';
+        dropdown.appendChild(defaultOpt);
+
+        for (let s of suggestions) {
+            const opt = document.createElement('option');
+            opt.value = s;
+            opt.innerText = s.length > 100 ? s.slice(0, 100) + "..." : s;
+            dropdown.appendChild(opt);
+        }
+
+        const wrapper = document.createElement("div");
+        wrapper.className = "grid w-full gap-1.5";
+
+        const container = document.createElement('div');
+        container.className = 'flex w-full gap-2';
+        container.appendChild(dropdown);
+
+        const configBtn = document.createElement('button');
+        configBtn.type = 'button';
+        configBtn.textContent = '⚙️';
+        configBtn.title = 'Settings';
+        configBtn.className = 'text-sm';
+        container.appendChild(configBtn);
+
+        const historyBtn = document.createElement('button');
+        historyBtn.type = 'button';
+        historyBtn.textContent = '🕘';
+        historyBtn.title = 'History';
+        historyBtn.className = 'text-sm';
+        container.appendChild(historyBtn);
+
+        wrapper.appendChild(container);
+        colDiv.insertBefore(wrapper, colDiv.firstChild);
+
+        configBtn.addEventListener('click', () => openSettings());
+        historyBtn.addEventListener('click', () => openHistory());
+
+        dropdown.addEventListener('change', () => {
+            const value = dropdown.value;
+            if (!value) return;
+
+            setPromptText(promptDiv, value);
+            dropdown.selectedIndex = 0;
+        });
+    }
+
+    // Wait until the main prompt input exists
+    function waitForPromptInput(callback) {
+        if (promptInputObserver) {
+            promptInputObserver.disconnect();
+            const idx = observers.indexOf(promptInputObserver);
+            if (idx !== -1) observers.splice(idx, 1);
+        }
+
+        const observer = new MutationObserver(() => {
+            const promptDiv = findPromptInput();
+            const colDiv = promptDiv?.closest('.flex-col.items-center');
+            if (promptDiv && colDiv) {
+                observer.disconnect();
+                const i = observers.indexOf(observer);
+                if (i !== -1) observers.splice(i, 1);
+                promptInputObserver = null;
+                callback(promptDiv, colDiv);
+            }
+        });
+
+        promptInputObserver = observer;
+        observers.push(observer);
+
+        observer.observe(document.body, { childList: true, subtree: true });
+
+        // Check immediately in case the element already exists
+        const promptDiv = findPromptInput();
+        const colDiv = promptDiv?.closest('.flex-col.items-center');
+        if (promptDiv && colDiv) {
+            observer.disconnect();
+            const i = observers.indexOf(observer);
+            if (i !== -1) observers.splice(i, 1);
+            promptInputObserver = null;
+            callback(promptDiv, colDiv);
+        }
+    }
+
+    waitForPromptInput((promptDiv, colDiv) => {
+        currentPromptDiv = promptDiv;
+        currentColDiv = colDiv;
+        if (dropdownObserver) {
+            dropdownObserver.disconnect();
+            const idx = observers.indexOf(dropdownObserver);
+            if (idx !== -1) observers.splice(idx, 1);
+            dropdownObserver = null;
+        }
+
+        injectDropdown(promptDiv, colDiv);
+
+        promptDiv.addEventListener('keydown', (e) => {
+            if (e.key === 'Enter' && !e.shiftKey && !e.isComposing) {
+                const text = promptDiv instanceof HTMLTextAreaElement ? promptDiv.value : promptDiv.textContent;
+                history = addToHistory(history, text);
+            }
+        });
+
+        const sendBtn = findSendButton();
+        if (sendBtn) {
+            sendBtn.addEventListener('click', () => {
+                const text = promptDiv instanceof HTMLTextAreaElement ? promptDiv.value : promptDiv.textContent;
+                history = addToHistory(history, text);
+            });
+        }
+
+        const observer = new MutationObserver(() => {
+            const pd = findPromptInput();
+            const cd = pd?.closest('.flex-col.items-center');
+            if (pd && cd && !document.getElementById('gpt-prompt-suggest-dropdown')) {
+                currentPromptDiv = pd;
+                currentColDiv = cd;
+                injectDropdown(pd, cd);
+            }
+        });
+
+        dropdownObserver = observer;
+        observers.push(observer);
+
+        observer.observe(document.body, { childList: true, subtree: true });
+    });
+})();

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,0 +1,19 @@
+export function loadJSON<T>(key: string, fallback: T): T {
+  try {
+    const raw = localStorage.getItem(key);
+    if (raw) {
+      return JSON.parse(raw) as T;
+    }
+  } catch (e) {
+    console.error(`Failed to load ${key}`, e);
+  }
+  return fallback;
+}
+
+export function saveJSON(key: string, data: any): void {
+  try {
+    localStorage.setItem(key, JSON.stringify(data));
+  } catch (e) {
+    console.error(`Failed to save ${key}`, e);
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "commonjs",
+    "rootDir": "src",
+    "outDir": "dist",
+    "esModuleInterop": true,
+    "strict": false
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- refactor to use a TypeScript source layout under `src/`
- add build script using esbuild and a Tampermonkey header file
- split helper utilities into `lib` and `helpers`
- document Violentmonkey installation and new build+test rules
- add AGENTS.md that enforces building and testing

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6870047a6bd88325bf750174d3102053