### PR TITLE
Add auto-archive settings

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -50,7 +50,9 @@
     showVersionSidebar: true,
     clearClosedBranches: false,
     clearMergedBranches: false,
-    clearOpenBranches: false
+    clearOpenBranches: false,
+    autoArchiveMerged: true,
+    autoArchiveClosed: true
   };
   var STORAGE_KEY = "gpt-script-options";
   function loadOptions() {
@@ -335,6 +337,8 @@
         <label><input type="checkbox" id="gpt-setting-clear-closed"> Auto-clear closed branches</label><br>
         <label><input type="checkbox" id="gpt-setting-clear-merged"> Auto-clear merged branches</label><br>
         <label><input type="checkbox" id="gpt-setting-clear-open"> Auto-clear open branches</label><br>
+        <label><input type="checkbox" id="gpt-setting-auto-archive-merged"> Auto-archive merged tasks</label><br>
+        <label><input type="checkbox" id="gpt-setting-auto-archive-closed"> Auto-archive closed tasks</label><br>
         <button id="gpt-update-check">Check for Updates</button><br>
         <div class="mt-2 text-right"><button id="gpt-settings-close">Close</button></div>
     </div>`;
@@ -474,6 +478,8 @@
       modal.querySelector("#gpt-setting-clear-closed").checked = options.clearClosedBranches;
       modal.querySelector("#gpt-setting-clear-merged").checked = options.clearMergedBranches;
       modal.querySelector("#gpt-setting-clear-open").checked = options.clearOpenBranches;
+      modal.querySelector("#gpt-setting-auto-archive-merged").checked = options.autoArchiveMerged;
+      modal.querySelector("#gpt-setting-auto-archive-closed").checked = options.autoArchiveClosed;
       modal.classList.add("show");
     }
     function renderHistory() {
@@ -575,6 +581,14 @@
       options.clearOpenBranches = e.target.checked;
       saveOptions(options);
     });
+    modal.querySelector("#gpt-setting-auto-archive-merged").addEventListener("change", (e) => {
+      options.autoArchiveMerged = e.target.checked;
+      saveOptions(options);
+    });
+    modal.querySelector("#gpt-setting-auto-archive-closed").addEventListener("change", (e) => {
+      options.autoArchiveClosed = e.target.checked;
+      saveOptions(options);
+    });
     modal.querySelector("#gpt-update-check").addEventListener("click", () => checkForUpdates());
     const pageObserver = new MutationObserver(() => {
       toggleHeader(options.hideHeader);
@@ -617,9 +631,9 @@
       if (status && status !== lastTaskStatus) {
         lastTaskStatus = status;
         if (/merged/i.test(status)) {
-          autoArchiveOnMerged();
+          if (options.autoArchiveMerged) autoArchiveOnMerged();
         } else if (/closed/i.test(status)) {
-          autoArchiveOnClosed();
+          if (options.autoArchiveClosed) autoArchiveOnClosed();
         }
       }
     }

--- a/openai-codex.user.js
+++ b/openai-codex.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.14
+// @version      1.15
 // @description  Adds a prompt suggestion dropdown above the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest
@@ -59,7 +59,9 @@
     showVersionSidebar: true,
     clearClosedBranches: false,
     clearMergedBranches: false,
-    clearOpenBranches: false
+    clearOpenBranches: false,
+    autoArchiveMerged: true,
+    autoArchiveClosed: true
   };
   var STORAGE_KEY = "gpt-script-options";
   function loadOptions() {
@@ -344,6 +346,8 @@
         <label><input type="checkbox" id="gpt-setting-clear-closed"> Auto-clear closed branches</label><br>
         <label><input type="checkbox" id="gpt-setting-clear-merged"> Auto-clear merged branches</label><br>
         <label><input type="checkbox" id="gpt-setting-clear-open"> Auto-clear open branches</label><br>
+        <label><input type="checkbox" id="gpt-setting-auto-archive-merged"> Auto-archive merged tasks</label><br>
+        <label><input type="checkbox" id="gpt-setting-auto-archive-closed"> Auto-archive closed tasks</label><br>
         <button id="gpt-update-check">Check for Updates</button><br>
         <div class="mt-2 text-right"><button id="gpt-settings-close">Close</button></div>
     </div>`;
@@ -483,6 +487,8 @@
       modal.querySelector("#gpt-setting-clear-closed").checked = options.clearClosedBranches;
       modal.querySelector("#gpt-setting-clear-merged").checked = options.clearMergedBranches;
       modal.querySelector("#gpt-setting-clear-open").checked = options.clearOpenBranches;
+      modal.querySelector("#gpt-setting-auto-archive-merged").checked = options.autoArchiveMerged;
+      modal.querySelector("#gpt-setting-auto-archive-closed").checked = options.autoArchiveClosed;
       modal.classList.add("show");
     }
     function renderHistory() {
@@ -584,6 +590,14 @@
       options.clearOpenBranches = e.target.checked;
       saveOptions(options);
     });
+    modal.querySelector("#gpt-setting-auto-archive-merged").addEventListener("change", (e) => {
+      options.autoArchiveMerged = e.target.checked;
+      saveOptions(options);
+    });
+    modal.querySelector("#gpt-setting-auto-archive-closed").addEventListener("change", (e) => {
+      options.autoArchiveClosed = e.target.checked;
+      saveOptions(options);
+    });
     modal.querySelector("#gpt-update-check").addEventListener("click", () => checkForUpdates());
     const pageObserver = new MutationObserver(() => {
       toggleHeader(options.hideHeader);
@@ -626,9 +640,9 @@
       if (status && status !== lastTaskStatus) {
         lastTaskStatus = status;
         if (/merged/i.test(status)) {
-          autoArchiveOnMerged();
+          if (options.autoArchiveMerged) autoArchiveOnMerged();
         } else if (/closed/i.test(status)) {
-          autoArchiveOnClosed();
+          if (options.autoArchiveClosed) autoArchiveOnClosed();
         }
       }
     }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openai-codex-userscript",
-      "version": "1.0.4",
+      "version": "1.0.5",
       "devDependencies": {
         "esbuild": "^0.25.6",
         "jsdom": "^24.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "scripts": {
     "build": "node build.js",
     "test": "npm run build && node test.js"

--- a/src/header.js
+++ b/src/header.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.14
+// @version      1.15
 // @description  Adds a prompt suggestion dropdown above the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest

--- a/src/helpers/options.ts
+++ b/src/helpers/options.ts
@@ -14,6 +14,8 @@ export interface Options {
   clearClosedBranches: boolean;
   clearMergedBranches: boolean;
   clearOpenBranches: boolean;
+  autoArchiveMerged: boolean;
+  autoArchiveClosed: boolean;
 }
 
 export const DEFAULT_OPTIONS: Options = {
@@ -30,6 +32,8 @@ export const DEFAULT_OPTIONS: Options = {
   clearClosedBranches: false,
   clearMergedBranches: false,
   clearOpenBranches: false,
+  autoArchiveMerged: true,
+  autoArchiveClosed: true,
 };
 
 const STORAGE_KEY = 'gpt-script-options';

--- a/src/index.ts
+++ b/src/index.ts
@@ -261,6 +261,8 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
         <label><input type="checkbox" id="gpt-setting-clear-closed"> Auto-clear closed branches</label><br>
         <label><input type="checkbox" id="gpt-setting-clear-merged"> Auto-clear merged branches</label><br>
         <label><input type="checkbox" id="gpt-setting-clear-open"> Auto-clear open branches</label><br>
+        <label><input type="checkbox" id="gpt-setting-auto-archive-merged"> Auto-archive merged tasks</label><br>
+        <label><input type="checkbox" id="gpt-setting-auto-archive-closed"> Auto-archive closed tasks</label><br>
         <button id="gpt-update-check">Check for Updates</button><br>
         <div class="mt-2 text-right"><button id="gpt-settings-close">Close</button></div>
     </div>`;
@@ -411,6 +413,8 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
         modal.querySelector('#gpt-setting-clear-closed').checked = options.clearClosedBranches;
         modal.querySelector('#gpt-setting-clear-merged').checked = options.clearMergedBranches;
         modal.querySelector('#gpt-setting-clear-open').checked = options.clearOpenBranches;
+        modal.querySelector('#gpt-setting-auto-archive-merged').checked = options.autoArchiveMerged;
+        modal.querySelector('#gpt-setting-auto-archive-closed').checked = options.autoArchiveClosed;
         modal.classList.add('show');
     }
 
@@ -459,6 +463,8 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
     modal.querySelector('#gpt-setting-clear-closed').addEventListener('change', (e) => { options.clearClosedBranches = e.target.checked; saveOptions(options); });
     modal.querySelector('#gpt-setting-clear-merged').addEventListener('change', (e) => { options.clearMergedBranches = e.target.checked; saveOptions(options); });
     modal.querySelector('#gpt-setting-clear-open').addEventListener('change', (e) => { options.clearOpenBranches = e.target.checked; saveOptions(options); });
+    modal.querySelector('#gpt-setting-auto-archive-merged').addEventListener('change', (e) => { options.autoArchiveMerged = e.target.checked; saveOptions(options); });
+    modal.querySelector('#gpt-setting-auto-archive-closed').addEventListener('change', (e) => { options.autoArchiveClosed = e.target.checked; saveOptions(options); });
     modal.querySelector('#gpt-update-check').addEventListener('click', () => checkForUpdates());
 
     const pageObserver = new MutationObserver(() => {
@@ -515,9 +521,9 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
         if (status && status !== lastTaskStatus) {
             lastTaskStatus = status;
             if (/merged/i.test(status)) {
-                autoArchiveOnMerged();
+                if (options.autoArchiveMerged) autoArchiveOnMerged();
             } else if (/closed/i.test(status)) {
-                autoArchiveOnClosed();
+                if (options.autoArchiveClosed) autoArchiveOnClosed();
             }
         }
     }


### PR DESCRIPTION
## Summary
- support autoArchiveMerged and autoArchiveClosed options
- expose new settings via modal checkboxes
- gate auto archive logic behind options
- bump version to 1.0.5

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68704539c1dc83259c5f71f27a53fd09