### PR TITLE
Add history limit options

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -52,7 +52,9 @@
     clearMergedBranches: false,
     clearOpenBranches: false,
     autoArchiveMerged: false,
-    autoArchiveClosed: false
+    autoArchiveClosed: false,
+    historyLimit: 50,
+    disableHistory: false
   };
   var STORAGE_KEY = "gpt-script-options";
   function loadOptions() {
@@ -85,7 +87,6 @@
 
   // src/helpers/history.ts
   var STORAGE_KEY3 = "gpt-prompt-history";
-  var MAX_HISTORY = 50;
   function loadHistory() {
     return loadJSON(STORAGE_KEY3, []);
   }
@@ -93,10 +94,13 @@
     saveJSON(STORAGE_KEY3, list);
   }
   function addToHistory(list, text) {
+    const opts = loadOptions();
+    if (opts.disableHistory) return list;
+    const limit = opts.historyLimit || 50;
     text = text.trim();
     if (!text) return list;
     list.unshift(text);
-    if (list.length > MAX_HISTORY) list.length = MAX_HISTORY;
+    if (list.length > limit) list.length = limit;
     saveHistory(list);
     return list;
   }
@@ -104,7 +108,7 @@
   // src/index.ts
   (function() {
     "use strict";
-    const SCRIPT_VERSION = "1.18";
+    const SCRIPT_VERSION = "1.19";
     const observers = [];
     let promptInputObserver = null;
     let dropdownObserver = null;
@@ -358,7 +362,9 @@
         </div>
         <div class="settings-group">
             <h3>Other</h3>
-            <label><input type="checkbox" id="gpt-setting-auto-updates"> Auto-check for updates</label>
+            <label><input type="checkbox" id="gpt-setting-auto-updates"> Auto-check for updates</label><br>
+            <label><input type="checkbox" id="gpt-setting-disable-history"> Disable prompt history</label><br>
+            <label>History limit <input type="number" id="gpt-setting-history-limit" min="1" style="width:4rem"></label>
         </div>
         <button id="gpt-update-check">Check for Updates</button><br>
         <div class="mt-2 text-right"><button id="gpt-settings-close">Close</button></div>
@@ -529,6 +535,8 @@
       modal.querySelector("#gpt-setting-profile").checked = options.hideProfile;
       modal.querySelector("#gpt-setting-environments").checked = options.hideEnvironments;
       modal.querySelector("#gpt-setting-auto-updates").checked = options.autoCheckUpdates;
+      modal.querySelector("#gpt-setting-disable-history").checked = options.disableHistory;
+      modal.querySelector("#gpt-setting-history-limit").value = String(options.historyLimit);
       modal.querySelector("#gpt-setting-show-repos").checked = options.showRepoSidebar;
       modal.querySelector("#gpt-setting-show-versions").checked = options.showVersionSidebar;
       modal.querySelector("#gpt-setting-clear-closed").checked = options.clearClosedBranches;
@@ -614,6 +622,14 @@
     });
     modal.querySelector("#gpt-setting-auto-updates").addEventListener("change", (e) => {
       options.autoCheckUpdates = e.target.checked;
+      saveOptions(options);
+    });
+    modal.querySelector("#gpt-setting-disable-history").addEventListener("change", (e) => {
+      options.disableHistory = e.target.checked;
+      saveOptions(options);
+    });
+    modal.querySelector("#gpt-setting-history-limit").addEventListener("change", (e) => {
+      options.historyLimit = parseInt(e.target.value, 10) || 1;
       saveOptions(options);
     });
     modal.querySelector("#gpt-setting-show-repos").addEventListener("change", (e) => {

--- a/openai-codex.user.js
+++ b/openai-codex.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.18
+// @version      1.19
 // @description  Adds a prompt suggestion dropdown above the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest
@@ -61,7 +61,9 @@
     clearMergedBranches: false,
     clearOpenBranches: false,
     autoArchiveMerged: false,
-    autoArchiveClosed: false
+    autoArchiveClosed: false,
+    historyLimit: 50,
+    disableHistory: false
   };
   var STORAGE_KEY = "gpt-script-options";
   function loadOptions() {
@@ -94,7 +96,6 @@
 
   // src/helpers/history.ts
   var STORAGE_KEY3 = "gpt-prompt-history";
-  var MAX_HISTORY = 50;
   function loadHistory() {
     return loadJSON(STORAGE_KEY3, []);
   }
@@ -102,10 +103,13 @@
     saveJSON(STORAGE_KEY3, list);
   }
   function addToHistory(list, text) {
+    const opts = loadOptions();
+    if (opts.disableHistory) return list;
+    const limit = opts.historyLimit || 50;
     text = text.trim();
     if (!text) return list;
     list.unshift(text);
-    if (list.length > MAX_HISTORY) list.length = MAX_HISTORY;
+    if (list.length > limit) list.length = limit;
     saveHistory(list);
     return list;
   }
@@ -113,7 +117,7 @@
   // src/index.ts
   (function() {
     "use strict";
-    const SCRIPT_VERSION = "1.18";
+    const SCRIPT_VERSION = "1.19";
     const observers = [];
     let promptInputObserver = null;
     let dropdownObserver = null;
@@ -367,7 +371,9 @@
         </div>
         <div class="settings-group">
             <h3>Other</h3>
-            <label><input type="checkbox" id="gpt-setting-auto-updates"> Auto-check for updates</label>
+            <label><input type="checkbox" id="gpt-setting-auto-updates"> Auto-check for updates</label><br>
+            <label><input type="checkbox" id="gpt-setting-disable-history"> Disable prompt history</label><br>
+            <label>History limit <input type="number" id="gpt-setting-history-limit" min="1" style="width:4rem"></label>
         </div>
         <button id="gpt-update-check">Check for Updates</button><br>
         <div class="mt-2 text-right"><button id="gpt-settings-close">Close</button></div>
@@ -538,6 +544,8 @@
       modal.querySelector("#gpt-setting-profile").checked = options.hideProfile;
       modal.querySelector("#gpt-setting-environments").checked = options.hideEnvironments;
       modal.querySelector("#gpt-setting-auto-updates").checked = options.autoCheckUpdates;
+      modal.querySelector("#gpt-setting-disable-history").checked = options.disableHistory;
+      modal.querySelector("#gpt-setting-history-limit").value = String(options.historyLimit);
       modal.querySelector("#gpt-setting-show-repos").checked = options.showRepoSidebar;
       modal.querySelector("#gpt-setting-show-versions").checked = options.showVersionSidebar;
       modal.querySelector("#gpt-setting-clear-closed").checked = options.clearClosedBranches;
@@ -623,6 +631,14 @@
     });
     modal.querySelector("#gpt-setting-auto-updates").addEventListener("change", (e) => {
       options.autoCheckUpdates = e.target.checked;
+      saveOptions(options);
+    });
+    modal.querySelector("#gpt-setting-disable-history").addEventListener("change", (e) => {
+      options.disableHistory = e.target.checked;
+      saveOptions(options);
+    });
+    modal.querySelector("#gpt-setting-history-limit").addEventListener("change", (e) => {
+      options.historyLimit = parseInt(e.target.value, 10) || 1;
       saveOptions(options);
     });
     modal.querySelector("#gpt-setting-show-repos").addEventListener("change", (e) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openai-codex-userscript",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "devDependencies": {
         "esbuild": "^0.25.6",
         "jsdom": "^24.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "scripts": {
     "build": "node build.js",
     "test": "npm run build && node test.js"

--- a/src/header.js
+++ b/src/header.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.18
+// @version      1.19
 // @description  Adds a prompt suggestion dropdown above the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest

--- a/src/helpers/history.ts
+++ b/src/helpers/history.ts
@@ -1,7 +1,7 @@
 import { loadJSON, saveJSON } from '../lib/storage';
+import { loadOptions } from './options';
 
 const STORAGE_KEY = 'gpt-prompt-history';
-const MAX_HISTORY = 50;
 
 export function loadHistory(): string[] {
   return loadJSON<string[]>(STORAGE_KEY, []);
@@ -12,10 +12,13 @@ export function saveHistory(list: string[]): void {
 }
 
 export function addToHistory(list: string[], text: string): string[] {
+  const opts = loadOptions();
+  if (opts.disableHistory) return list;
+  const limit = opts.historyLimit || 50;
   text = text.trim();
   if (!text) return list;
   list.unshift(text);
-  if (list.length > MAX_HISTORY) list.length = MAX_HISTORY;
+  if (list.length > limit) list.length = limit;
   saveHistory(list);
   return list;
 }

--- a/src/helpers/options.ts
+++ b/src/helpers/options.ts
@@ -16,6 +16,8 @@ export interface Options {
   clearOpenBranches: boolean;
   autoArchiveMerged: boolean;
   autoArchiveClosed: boolean;
+  historyLimit: number;
+  disableHistory: boolean;
 }
 
 export const DEFAULT_OPTIONS: Options = {
@@ -34,6 +36,8 @@ export const DEFAULT_OPTIONS: Options = {
   clearOpenBranches: false,
   autoArchiveMerged: false,
   autoArchiveClosed: false,
+  historyLimit: 50,
+  disableHistory: false,
 };
 
 const STORAGE_KEY = 'gpt-script-options';

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
 (function () {
 
     'use strict';
-    const SCRIPT_VERSION = '1.18';
+    const SCRIPT_VERSION = '1.19';
     const observers = [];
     let promptInputObserver = null;
     let dropdownObserver = null;
@@ -282,7 +282,9 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
         </div>
         <div class="settings-group">
             <h3>Other</h3>
-            <label><input type="checkbox" id="gpt-setting-auto-updates"> Auto-check for updates</label>
+            <label><input type="checkbox" id="gpt-setting-auto-updates"> Auto-check for updates</label><br>
+            <label><input type="checkbox" id="gpt-setting-disable-history"> Disable prompt history</label><br>
+            <label>History limit <input type="number" id="gpt-setting-history-limit" min="1" style="width:4rem"></label>
         </div>
         <button id="gpt-update-check">Check for Updates</button><br>
         <div class="mt-2 text-right"><button id="gpt-settings-close">Close</button></div>
@@ -464,6 +466,8 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
         modal.querySelector('#gpt-setting-profile').checked = options.hideProfile;
         modal.querySelector('#gpt-setting-environments').checked = options.hideEnvironments;
         modal.querySelector('#gpt-setting-auto-updates').checked = options.autoCheckUpdates;
+        modal.querySelector('#gpt-setting-disable-history').checked = options.disableHistory;
+        modal.querySelector('#gpt-setting-history-limit').value = String(options.historyLimit);
         modal.querySelector('#gpt-setting-show-repos').checked = options.showRepoSidebar;
         modal.querySelector('#gpt-setting-show-versions').checked = options.showVersionSidebar;
         modal.querySelector('#gpt-setting-clear-closed').checked = options.clearClosedBranches;
@@ -515,6 +519,8 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
     modal.querySelector('#gpt-setting-profile').addEventListener('change', (e) => { options.hideProfile = e.target.checked; saveOptions(options); applyOptions(); });
     modal.querySelector('#gpt-setting-environments').addEventListener('change', (e) => { options.hideEnvironments = e.target.checked; saveOptions(options); applyOptions(); });
     modal.querySelector('#gpt-setting-auto-updates').addEventListener('change', (e) => { options.autoCheckUpdates = e.target.checked; saveOptions(options); });
+    modal.querySelector('#gpt-setting-disable-history').addEventListener('change', (e) => { options.disableHistory = e.target.checked; saveOptions(options); });
+    modal.querySelector('#gpt-setting-history-limit').addEventListener('change', (e) => { options.historyLimit = parseInt(e.target.value, 10) || 1; saveOptions(options); });
     modal.querySelector('#gpt-setting-show-repos').addEventListener('change', (e) => { options.showRepoSidebar = e.target.checked; saveOptions(options); applyOptions(); });
     modal.querySelector('#gpt-setting-show-versions').addEventListener('change', (e) => { options.showVersionSidebar = e.target.checked; saveOptions(options); applyOptions(); });
     modal.querySelector('#gpt-setting-clear-closed').addEventListener('change', (e) => { options.clearClosedBranches = e.target.checked; saveOptions(options); });


### PR DESCRIPTION
## Summary
- add `historyLimit` and `disableHistory` to options
- respect new settings when storing prompt history
- surface history settings in the modal
- bump version to 1.0.9 / script v1.19

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68712173d1288325b30af134182e175c