### PR TITLE
Add font customization options

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -39,6 +39,8 @@
   // src/helpers/options.ts
   var DEFAULT_OPTIONS = {
     theme: null,
+    font: "sans-serif",
+    customFont: "",
     hideHeader: false,
     hideDocs: false,
     hideLogoText: false,
@@ -104,7 +106,7 @@
   // src/index.ts
   (function() {
     "use strict";
-    const SCRIPT_VERSION = "1.18";
+    const SCRIPT_VERSION = "1.19";
     const observers = [];
     let promptInputObserver = null;
     let dropdownObserver = null;
@@ -270,6 +272,19 @@
       root.classList.add(`userscript-force-${theme}`);
       root.classList.add(theme);
       root.style.colorScheme = theme;
+      switch (options.font) {
+        case "serif":
+          root.style.fontFamily = "serif";
+          break;
+        case "monospace":
+          root.style.fontFamily = "monospace";
+          break;
+        case "custom":
+          root.style.fontFamily = options.customFont || "inherit";
+          break;
+        default:
+          root.style.fontFamily = "sans-serif";
+      }
       toggleHeader(options.hideHeader);
       toggleDocs(options.hideDocs);
       toggleLogoText(options.hideLogoText);
@@ -333,6 +348,18 @@
                     <option value="oled">OLED</option>
                 </select>
             </label>
+        </div>
+        <div class="settings-group">
+            <h3>Font</h3>
+            <label>
+                <select id="gpt-setting-font">
+                    <option value="sans-serif">Sans-serif</option>
+                    <option value="serif">Serif</option>
+                    <option value="monospace">Monospace</option>
+                    <option value="custom">Custom</option>
+                </select>
+            </label>
+            <input type="text" id="gpt-setting-custom-font" placeholder="Custom font" class="mt-1">
         </div>
         <div class="settings-group">
             <h3>Interface</h3>
@@ -522,6 +549,10 @@
       const prefersDark = typeof window.matchMedia === "function" && window.matchMedia("(prefers-color-scheme: dark)").matches;
       const systemTheme = prefersDark ? "dark" : "light";
       themeSelect.value = options.theme || systemTheme;
+      const fontSelect = modal.querySelector("#gpt-setting-font");
+      const customFontInput = modal.querySelector("#gpt-setting-custom-font");
+      fontSelect.value = options.font;
+      if (customFontInput) customFontInput.value = options.customFont;
       modal.querySelector("#gpt-setting-header").checked = options.hideHeader;
       modal.querySelector("#gpt-setting-docs").checked = options.hideDocs;
       modal.querySelector("#gpt-setting-logo-text").checked = options.hideLogoText;
@@ -579,6 +610,16 @@
     });
     modal.querySelector("#gpt-setting-theme").addEventListener("change", (e) => {
       options.theme = e.target.value;
+      saveOptions(options);
+      applyOptions();
+    });
+    modal.querySelector("#gpt-setting-font").addEventListener("change", (e) => {
+      options.font = e.target.value;
+      saveOptions(options);
+      applyOptions();
+    });
+    modal.querySelector("#gpt-setting-custom-font").addEventListener("input", (e) => {
+      options.customFont = e.target.value;
       saveOptions(options);
       applyOptions();
     });

--- a/openai-codex.user.js
+++ b/openai-codex.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.18
+// @version      1.19
 // @description  Adds a prompt suggestion dropdown above the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest
@@ -48,6 +48,8 @@
   // src/helpers/options.ts
   var DEFAULT_OPTIONS = {
     theme: null,
+    font: "sans-serif",
+    customFont: "",
     hideHeader: false,
     hideDocs: false,
     hideLogoText: false,
@@ -113,7 +115,7 @@
   // src/index.ts
   (function() {
     "use strict";
-    const SCRIPT_VERSION = "1.18";
+    const SCRIPT_VERSION = "1.19";
     const observers = [];
     let promptInputObserver = null;
     let dropdownObserver = null;
@@ -279,6 +281,19 @@
       root.classList.add(`userscript-force-${theme}`);
       root.classList.add(theme);
       root.style.colorScheme = theme;
+      switch (options.font) {
+        case "serif":
+          root.style.fontFamily = "serif";
+          break;
+        case "monospace":
+          root.style.fontFamily = "monospace";
+          break;
+        case "custom":
+          root.style.fontFamily = options.customFont || "inherit";
+          break;
+        default:
+          root.style.fontFamily = "sans-serif";
+      }
       toggleHeader(options.hideHeader);
       toggleDocs(options.hideDocs);
       toggleLogoText(options.hideLogoText);
@@ -342,6 +357,18 @@
                     <option value="oled">OLED</option>
                 </select>
             </label>
+        </div>
+        <div class="settings-group">
+            <h3>Font</h3>
+            <label>
+                <select id="gpt-setting-font">
+                    <option value="sans-serif">Sans-serif</option>
+                    <option value="serif">Serif</option>
+                    <option value="monospace">Monospace</option>
+                    <option value="custom">Custom</option>
+                </select>
+            </label>
+            <input type="text" id="gpt-setting-custom-font" placeholder="Custom font" class="mt-1">
         </div>
         <div class="settings-group">
             <h3>Interface</h3>
@@ -531,6 +558,10 @@
       const prefersDark = typeof window.matchMedia === "function" && window.matchMedia("(prefers-color-scheme: dark)").matches;
       const systemTheme = prefersDark ? "dark" : "light";
       themeSelect.value = options.theme || systemTheme;
+      const fontSelect = modal.querySelector("#gpt-setting-font");
+      const customFontInput = modal.querySelector("#gpt-setting-custom-font");
+      fontSelect.value = options.font;
+      if (customFontInput) customFontInput.value = options.customFont;
       modal.querySelector("#gpt-setting-header").checked = options.hideHeader;
       modal.querySelector("#gpt-setting-docs").checked = options.hideDocs;
       modal.querySelector("#gpt-setting-logo-text").checked = options.hideLogoText;
@@ -588,6 +619,16 @@
     });
     modal.querySelector("#gpt-setting-theme").addEventListener("change", (e) => {
       options.theme = e.target.value;
+      saveOptions(options);
+      applyOptions();
+    });
+    modal.querySelector("#gpt-setting-font").addEventListener("change", (e) => {
+      options.font = e.target.value;
+      saveOptions(options);
+      applyOptions();
+    });
+    modal.querySelector("#gpt-setting-custom-font").addEventListener("input", (e) => {
+      options.customFont = e.target.value;
       saveOptions(options);
       applyOptions();
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openai-codex-userscript",
-      "version": "1.0.8",
+      "version": "1.0.9",
       "devDependencies": {
         "esbuild": "^0.25.6",
         "jsdom": "^24.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "scripts": {
     "build": "node build.js",
     "test": "npm run build && node test.js"

--- a/src/header.js
+++ b/src/header.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.18
+// @version      1.19
 // @description  Adds a prompt suggestion dropdown above the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest

--- a/src/helpers/options.ts
+++ b/src/helpers/options.ts
@@ -2,6 +2,8 @@ import { loadJSON, saveJSON } from '../lib/storage';
 
 export interface Options {
   theme: string | null;
+  font: 'serif' | 'sans-serif' | 'monospace' | 'custom';
+  customFont: string;
   hideHeader: boolean;
   hideDocs: boolean;
   hideLogoText: boolean;
@@ -20,6 +22,8 @@ export interface Options {
 
 export const DEFAULT_OPTIONS: Options = {
   theme: null,
+  font: 'sans-serif',
+  customFont: '',
   hideHeader: false,
   hideDocs: false,
   hideLogoText: false,

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
 (function () {
 
     'use strict';
-    const SCRIPT_VERSION = '1.18';
+    const SCRIPT_VERSION = '1.19';
     const observers = [];
     let promptInputObserver = null;
     let dropdownObserver = null;
@@ -191,6 +191,19 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
         root.classList.add(`userscript-force-${theme}`);
         root.classList.add(theme);
         root.style.colorScheme = theme;
+        switch (options.font) {
+            case 'serif':
+                root.style.fontFamily = 'serif';
+                break;
+            case 'monospace':
+                root.style.fontFamily = 'monospace';
+                break;
+            case 'custom':
+                root.style.fontFamily = options.customFont || 'inherit';
+                break;
+            default:
+                root.style.fontFamily = 'sans-serif';
+        }
         toggleHeader(options.hideHeader);
         toggleDocs(options.hideDocs);
         toggleLogoText(options.hideLogoText);
@@ -257,6 +270,18 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
                     <option value="oled">OLED</option>
                 </select>
             </label>
+        </div>
+        <div class="settings-group">
+            <h3>Font</h3>
+            <label>
+                <select id="gpt-setting-font">
+                    <option value="sans-serif">Sans-serif</option>
+                    <option value="serif">Serif</option>
+                    <option value="monospace">Monospace</option>
+                    <option value="custom">Custom</option>
+                </select>
+            </label>
+            <input type="text" id="gpt-setting-custom-font" placeholder="Custom font" class="mt-1">
         </div>
         <div class="settings-group">
             <h3>Interface</h3>
@@ -457,6 +482,10 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
         const prefersDark = typeof window.matchMedia === 'function' && window.matchMedia('(prefers-color-scheme: dark)').matches;
         const systemTheme = prefersDark ? 'dark' : 'light';
         themeSelect.value = options.theme || systemTheme;
+        const fontSelect = modal.querySelector('#gpt-setting-font');
+        const customFontInput = modal.querySelector('#gpt-setting-custom-font');
+        fontSelect.value = options.font;
+        if (customFontInput) customFontInput.value = options.customFont;
         modal.querySelector('#gpt-setting-header').checked = options.hideHeader;
         modal.querySelector('#gpt-setting-docs').checked = options.hideDocs;
         modal.querySelector('#gpt-setting-logo-text').checked = options.hideLogoText;
@@ -508,6 +537,8 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
     historyModal.addEventListener('click', (e) => { if (e.target === historyModal) historyModal.classList.remove('show'); });
     historyModal.querySelector('#gpt-history-clear').addEventListener('click', () => { history = []; saveHistory(history); renderHistory(); });
     modal.querySelector('#gpt-setting-theme').addEventListener('change', (e) => { options.theme = e.target.value; saveOptions(options); applyOptions(); });
+    modal.querySelector('#gpt-setting-font').addEventListener('change', (e) => { options.font = e.target.value; saveOptions(options); applyOptions(); });
+    modal.querySelector('#gpt-setting-custom-font').addEventListener('input', (e) => { options.customFont = e.target.value; saveOptions(options); applyOptions(); });
     modal.querySelector('#gpt-setting-header').addEventListener('change', (e) => { options.hideHeader = e.target.checked; saveOptions(options); applyOptions(); });
     modal.querySelector('#gpt-setting-docs').addEventListener('change', (e) => { options.hideDocs = e.target.checked; saveOptions(options); applyOptions(); });
     modal.querySelector('#gpt-setting-logo-text').addEventListener('change', (e) => { options.hideLogoText = e.target.checked; saveOptions(options); applyOptions(); });


### PR DESCRIPTION
## Summary
- support serif/sans-serif/monospace/custom fonts in options
- expose new font selector & custom field in settings modal
- apply selected font in `applyOptions`
- bump version numbers

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68712167d52c8325a5e2df9b870928bb