### PR TITLE
Implement header/env tweaks and floating history button

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -104,7 +104,7 @@
   // src/index.ts
   (function() {
     "use strict";
-    const SCRIPT_VERSION = "1.18";
+    const SCRIPT_VERSION = "1.19";
     const observers = [];
     let promptInputObserver = null;
     let dropdownObserver = null;
@@ -166,7 +166,29 @@
     cursor: pointer;
     box-shadow: 0 2px 4px rgba(0,0,0,0.2);
 }
+#gpt-history-gear {
+    position: fixed;
+    top: auto;
+    right: 56px;
+    bottom: 16px;
+    z-index: 1000;
+    background: var(--background);
+    color: var(--foreground);
+    border: 1px solid var(--ring);
+    width: 32px;
+    height: 32px;
+    border-radius: 9999px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+}
 #gpt-settings-gear:hover {
+    background: var(--ring);
+    color: var(--background);
+}
+#gpt-history-gear:hover {
     background: var(--ring);
     color: var(--background);
 }
@@ -225,8 +247,11 @@
       return elements.find((el) => el.textContent && el.textContent.includes(text)) || null;
     }
     function toggleHeader(hide) {
-      const node = findByText("What are we coding next?");
-      if (node) node.style.display = hide ? "none" : "";
+      var _a;
+      const node = document.querySelector("h1.mb-4.pt-4.text-2xl");
+      if (node && ((_a = node.textContent) == null ? void 0 : _a.includes("What are we coding next?"))) {
+        node.style.display = hide ? "none" : "";
+      }
     }
     function toggleDocs(hide) {
       const links = Array.from(document.querySelectorAll("a")).filter((a) => a.textContent && a.textContent.includes("Docs"));
@@ -249,10 +274,8 @@
       if (node) node.style.display = hide ? "none" : "";
     }
     function toggleEnvironments(hide) {
-      const buttons = Array.from(document.querySelectorAll("button")).filter((b) => b.textContent && b.textContent.toLowerCase().includes("environment"));
-      for (const btn of buttons) {
-        btn.style.display = hide ? "none" : "";
-      }
+      const link = document.querySelector('a[href="/codex/settings/environments"]');
+      if (link) link.style.display = hide ? "none" : "";
     }
     function toggleRepoSidebar(show) {
       const el = document.getElementById("gpt-repo-sidebar");
@@ -314,6 +337,10 @@
         console.error("Failed to check for updates", e);
       }
     }
+    const historyGear = document.createElement("div");
+    historyGear.id = "gpt-history-gear";
+    historyGear.textContent = "\u{1F4DC}";
+    document.body.appendChild(historyGear);
     const gear = document.createElement("div");
     gear.id = "gpt-settings-gear";
     gear.textContent = "\u2699\uFE0F";
@@ -563,6 +590,7 @@
       renderHistory();
       historyModal.classList.add("show");
     }
+    historyGear.addEventListener("click", openHistory);
     gear.addEventListener("click", openSettings);
     modal.querySelector("#gpt-settings-close").addEventListener("click", () => modal.classList.remove("show"));
     modal.addEventListener("click", (e) => {

--- a/openai-codex.user.js
+++ b/openai-codex.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.18
+// @version      1.19
 // @description  Adds a prompt suggestion dropdown above the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest
@@ -113,7 +113,7 @@
   // src/index.ts
   (function() {
     "use strict";
-    const SCRIPT_VERSION = "1.18";
+    const SCRIPT_VERSION = "1.19";
     const observers = [];
     let promptInputObserver = null;
     let dropdownObserver = null;
@@ -175,7 +175,29 @@
     cursor: pointer;
     box-shadow: 0 2px 4px rgba(0,0,0,0.2);
 }
+#gpt-history-gear {
+    position: fixed;
+    top: auto;
+    right: 56px;
+    bottom: 16px;
+    z-index: 1000;
+    background: var(--background);
+    color: var(--foreground);
+    border: 1px solid var(--ring);
+    width: 32px;
+    height: 32px;
+    border-radius: 9999px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+}
 #gpt-settings-gear:hover {
+    background: var(--ring);
+    color: var(--background);
+}
+#gpt-history-gear:hover {
     background: var(--ring);
     color: var(--background);
 }
@@ -234,8 +256,11 @@
       return elements.find((el) => el.textContent && el.textContent.includes(text)) || null;
     }
     function toggleHeader(hide) {
-      const node = findByText("What are we coding next?");
-      if (node) node.style.display = hide ? "none" : "";
+      var _a;
+      const node = document.querySelector("h1.mb-4.pt-4.text-2xl");
+      if (node && ((_a = node.textContent) == null ? void 0 : _a.includes("What are we coding next?"))) {
+        node.style.display = hide ? "none" : "";
+      }
     }
     function toggleDocs(hide) {
       const links = Array.from(document.querySelectorAll("a")).filter((a) => a.textContent && a.textContent.includes("Docs"));
@@ -258,10 +283,8 @@
       if (node) node.style.display = hide ? "none" : "";
     }
     function toggleEnvironments(hide) {
-      const buttons = Array.from(document.querySelectorAll("button")).filter((b) => b.textContent && b.textContent.toLowerCase().includes("environment"));
-      for (const btn of buttons) {
-        btn.style.display = hide ? "none" : "";
-      }
+      const link = document.querySelector('a[href="/codex/settings/environments"]');
+      if (link) link.style.display = hide ? "none" : "";
     }
     function toggleRepoSidebar(show) {
       const el = document.getElementById("gpt-repo-sidebar");
@@ -323,6 +346,10 @@
         console.error("Failed to check for updates", e);
       }
     }
+    const historyGear = document.createElement("div");
+    historyGear.id = "gpt-history-gear";
+    historyGear.textContent = "\u{1F4DC}";
+    document.body.appendChild(historyGear);
     const gear = document.createElement("div");
     gear.id = "gpt-settings-gear";
     gear.textContent = "\u2699\uFE0F";
@@ -572,6 +599,7 @@
       renderHistory();
       historyModal.classList.add("show");
     }
+    historyGear.addEventListener("click", openHistory);
     gear.addEventListener("click", openSettings);
     modal.querySelector("#gpt-settings-close").addEventListener("click", () => modal.classList.remove("show"));
     modal.addEventListener("click", (e) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.8",
+  "version": "1.0.9",
   "scripts": {
     "build": "node build.js",
     "test": "npm run build && node test.js"

--- a/src/header.js
+++ b/src/header.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.18
+// @version      1.19
 // @description  Adds a prompt suggestion dropdown above the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
 (function () {
 
     'use strict';
-    const SCRIPT_VERSION = '1.18';
+    const SCRIPT_VERSION = '1.19';
     const observers = [];
     let promptInputObserver = null;
     let dropdownObserver = null;
@@ -71,7 +71,29 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
     cursor: pointer;
     box-shadow: 0 2px 4px rgba(0,0,0,0.2);
 }
+#gpt-history-gear {
+    position: fixed;
+    top: auto;
+    right: 56px;
+    bottom: 16px;
+    z-index: 1000;
+    background: var(--background);
+    color: var(--foreground);
+    border: 1px solid var(--ring);
+    width: 32px;
+    height: 32px;
+    border-radius: 9999px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+}
 #gpt-settings-gear:hover {
+    background: var(--ring);
+    color: var(--background);
+}
+#gpt-history-gear:hover {
     background: var(--ring);
     color: var(--background);
 }
@@ -136,8 +158,10 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
     }
 
     function toggleHeader(hide) {
-        const node = findByText('What are we coding next?');
-        if (node) node.style.display = hide ? 'none' : '';
+        const node = document.querySelector('h1.mb-4.pt-4.text-2xl');
+        if (node && node.textContent?.includes('What are we coding next?')) {
+            node.style.display = hide ? 'none' : '';
+        }
     }
 
     function toggleDocs(hide) {
@@ -166,11 +190,8 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
     }
 
     function toggleEnvironments(hide) {
-        const buttons = Array.from(document.querySelectorAll('button'))
-            .filter(b => b.textContent && b.textContent.toLowerCase().includes('environment'));
-        for (const btn of buttons) {
-            btn.style.display = hide ? 'none' : '';
-        }
+        const link = document.querySelector('a[href="/codex/settings/environments"]');
+        if (link) link.style.display = hide ? 'none' : '';
     }
 
     function toggleRepoSidebar(show) {
@@ -236,6 +257,11 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
             console.error('Failed to check for updates', e);
         }
     }
+
+    const historyGear = document.createElement('div');
+    historyGear.id = 'gpt-history-gear';
+    historyGear.textContent = '📜';
+    document.body.appendChild(historyGear);
 
     const gear = document.createElement('div');
     gear.id = 'gpt-settings-gear';
@@ -501,6 +527,7 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
         historyModal.classList.add('show');
     }
 
+    historyGear.addEventListener('click', openHistory);
     gear.addEventListener('click', openSettings);
     modal.querySelector('#gpt-settings-close').addEventListener('click', () => modal.classList.remove('show'));
     modal.addEventListener('click', (e) => { if (e.target === modal) modal.classList.remove('show'); });


### PR DESCRIPTION
## Summary
- bump version to 1.19
- hide header and environment links more precisely
- add floating history button to open prompt history
- place history button before the settings gear

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6871246dd16083259a3ac054dc0fd2d6