### PR TITLE
Add prompt history management controls

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -110,7 +110,7 @@
   // src/index.ts
   (function() {
     "use strict";
-    const SCRIPT_VERSION = "1.19";
+    const SCRIPT_VERSION = "1.20";
     const observers = [];
     let promptInputObserver = null;
     let dropdownObserver = null;
@@ -611,7 +611,7 @@
       history.forEach((h, i) => {
         const li = document.createElement("li");
         const span = document.createElement("span");
-        span.textContent = h;
+        span.textContent = h.split(/\r?\n/)[0];
         li.appendChild(span);
         const useBtn = document.createElement("button");
         useBtn.className = "btn relative btn-secondary btn-small";
@@ -621,6 +621,22 @@
           historyModal.classList.remove("show");
         });
         li.appendChild(useBtn);
+        const restoreBtn = document.createElement("button");
+        restoreBtn.className = "btn relative btn-secondary btn-small";
+        restoreBtn.textContent = "Restore";
+        restoreBtn.addEventListener("click", () => {
+          setPromptText(currentPromptDiv || findPromptInput(), h);
+        });
+        li.appendChild(restoreBtn);
+        const delBtn = document.createElement("button");
+        delBtn.className = "btn relative btn-secondary btn-small";
+        delBtn.textContent = "Delete";
+        delBtn.addEventListener("click", () => {
+          history.splice(i, 1);
+          saveHistory(history);
+          renderHistory();
+        });
+        li.appendChild(delBtn);
         ul.appendChild(li);
       });
       wrap.appendChild(ul);

--- a/openai-codex.user.js
+++ b/openai-codex.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.19
+// @version      1.20
 // @description  Adds a prompt suggestion dropdown above the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest
@@ -119,7 +119,7 @@
   // src/index.ts
   (function() {
     "use strict";
-    const SCRIPT_VERSION = "1.19";
+    const SCRIPT_VERSION = "1.20";
     const observers = [];
     let promptInputObserver = null;
     let dropdownObserver = null;
@@ -620,7 +620,7 @@
       history.forEach((h, i) => {
         const li = document.createElement("li");
         const span = document.createElement("span");
-        span.textContent = h;
+        span.textContent = h.split(/\r?\n/)[0];
         li.appendChild(span);
         const useBtn = document.createElement("button");
         useBtn.className = "btn relative btn-secondary btn-small";
@@ -630,6 +630,22 @@
           historyModal.classList.remove("show");
         });
         li.appendChild(useBtn);
+        const restoreBtn = document.createElement("button");
+        restoreBtn.className = "btn relative btn-secondary btn-small";
+        restoreBtn.textContent = "Restore";
+        restoreBtn.addEventListener("click", () => {
+          setPromptText(currentPromptDiv || findPromptInput(), h);
+        });
+        li.appendChild(restoreBtn);
+        const delBtn = document.createElement("button");
+        delBtn.className = "btn relative btn-secondary btn-small";
+        delBtn.textContent = "Delete";
+        delBtn.addEventListener("click", () => {
+          history.splice(i, 1);
+          saveHistory(history);
+          renderHistory();
+        });
+        li.appendChild(delBtn);
         ul.appendChild(li);
       });
       wrap.appendChild(ul);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openai-codex-userscript",
-      "version": "1.0.9",
+      "version": "1.0.10",
       "devDependencies": {
         "esbuild": "^0.25.6",
         "jsdom": "^24.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.9",
+  "version": "1.0.10",
   "scripts": {
     "build": "node build.js",
     "test": "npm run build && node test.js"

--- a/src/header.js
+++ b/src/header.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.19
+// @version      1.20
 // @description  Adds a prompt suggestion dropdown above the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
 (function () {
 
     'use strict';
-    const SCRIPT_VERSION = '1.19';
+    const SCRIPT_VERSION = '1.20';
     const observers = [];
     let promptInputObserver = null;
     let dropdownObserver = null;
@@ -540,8 +540,9 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
         history.forEach((h, i) => {
             const li = document.createElement('li');
             const span = document.createElement('span');
-            span.textContent = h;
+            span.textContent = h.split(/\r?\n/)[0];
             li.appendChild(span);
+
             const useBtn = document.createElement('button');
             useBtn.className = 'btn relative btn-secondary btn-small';
             useBtn.textContent = 'Use';
@@ -550,6 +551,25 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
                 historyModal.classList.remove('show');
             });
             li.appendChild(useBtn);
+
+            const restoreBtn = document.createElement('button');
+            restoreBtn.className = 'btn relative btn-secondary btn-small';
+            restoreBtn.textContent = 'Restore';
+            restoreBtn.addEventListener('click', () => {
+                setPromptText(currentPromptDiv || findPromptInput(), h);
+            });
+            li.appendChild(restoreBtn);
+
+            const delBtn = document.createElement('button');
+            delBtn.className = 'btn relative btn-secondary btn-small';
+            delBtn.textContent = 'Delete';
+            delBtn.addEventListener('click', () => {
+                history.splice(i, 1);
+                saveHistory(history);
+                renderHistory();
+            });
+            li.appendChild(delBtn);
+
             ul.appendChild(li);
         });
         wrap.appendChild(ul);


### PR DESCRIPTION
## Summary
- show only the first line for each saved prompt in history
- allow restoring prompts without closing the history modal
- delete unwanted history entries
- bump version to 1.20

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68716fb61f788325b7947cdbda6bdf64