### PR TITLE
Add version info to settings modal

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -110,7 +110,7 @@
   // src/index.ts
   (function() {
     "use strict";
-    const SCRIPT_VERSION = "1.21";
+    const SCRIPT_VERSION = "1.22";
     const observers = [];
     let promptInputObserver = null;
     let dropdownObserver = null;
@@ -377,6 +377,7 @@
     modal.innerHTML = `
     <div class="modal-content">
         <h2 class="mb-2 text-lg">Settings</h2>
+        <div id="gpt-settings-version" class="mb-2 text-sm"></div>
         <div id="gpt-settings-suggestions"></div>
         <div class="settings-group">
             <h3>Theme</h3>
@@ -604,6 +605,8 @@
     }
     function openSettings() {
       renderSuggestions();
+      const versionEl = modal.querySelector("#gpt-settings-version");
+      if (versionEl) versionEl.textContent = `Version ${SCRIPT_VERSION}`;
       const themeSelect = modal.querySelector("#gpt-setting-theme");
       const prefersDark = typeof window.matchMedia === "function" && window.matchMedia("(prefers-color-scheme: dark)").matches;
       const systemTheme = prefersDark ? "dark" : "light";

--- a/openai-codex.user.js
+++ b/openai-codex.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.21
+// @version      1.22
 // @description  Adds a prompt suggestion dropdown above the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest
@@ -119,7 +119,7 @@
   // src/index.ts
   (function() {
     "use strict";
-    const SCRIPT_VERSION = "1.21";
+    const SCRIPT_VERSION = "1.22";
     const observers = [];
     let promptInputObserver = null;
     let dropdownObserver = null;
@@ -386,6 +386,7 @@
     modal.innerHTML = `
     <div class="modal-content">
         <h2 class="mb-2 text-lg">Settings</h2>
+        <div id="gpt-settings-version" class="mb-2 text-sm"></div>
         <div id="gpt-settings-suggestions"></div>
         <div class="settings-group">
             <h3>Theme</h3>
@@ -613,6 +614,8 @@
     }
     function openSettings() {
       renderSuggestions();
+      const versionEl = modal.querySelector("#gpt-settings-version");
+      if (versionEl) versionEl.textContent = `Version ${SCRIPT_VERSION}`;
       const themeSelect = modal.querySelector("#gpt-setting-theme");
       const prefersDark = typeof window.matchMedia === "function" && window.matchMedia("(prefers-color-scheme: dark)").matches;
       const systemTheme = prefersDark ? "dark" : "light";

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openai-codex-userscript",
-      "version": "1.0.11",
+      "version": "1.0.12",
       "devDependencies": {
         "esbuild": "^0.25.6",
         "jsdom": "^24.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.11",
+  "version": "1.0.12",
   "scripts": {
     "build": "node build.js",
     "test": "npm run build && node test.js"

--- a/src/header.js
+++ b/src/header.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.21
+// @version      1.22
 // @description  Adds a prompt suggestion dropdown above the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
 (function () {
 
     'use strict';
-    const SCRIPT_VERSION = '1.21';
+    const SCRIPT_VERSION = '1.22';
     const observers = [];
     let promptInputObserver = null;
     let dropdownObserver = null;
@@ -294,6 +294,7 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
     modal.innerHTML = `
     <div class="modal-content">
         <h2 class="mb-2 text-lg">Settings</h2>
+        <div id="gpt-settings-version" class="mb-2 text-sm"></div>
         <div id="gpt-settings-suggestions"></div>
         <div class="settings-group">
             <h3>Theme</h3>
@@ -534,6 +535,8 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
 
     function openSettings() {
         renderSuggestions();
+        const versionEl = modal.querySelector('#gpt-settings-version');
+        if (versionEl) versionEl.textContent = `Version ${SCRIPT_VERSION}`;
         const themeSelect = modal.querySelector('#gpt-setting-theme');
         const prefersDark = typeof window.matchMedia === 'function' && window.matchMedia('(prefers-color-scheme: dark)').matches;
         const systemTheme = prefersDark ? 'dark' : 'light';


### PR DESCRIPTION
## Summary
- show the script version inside the settings modal
- populate version text when opening the modal
- bump package version to 1.0.12 and userscript version to 1.22

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6871791e40b0832597180f6f9fa3aff5