### PR TITLE
Remove redundant history button

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -110,7 +110,7 @@
   // src/index.ts
   (function() {
     "use strict";
-    const SCRIPT_VERSION = "1.23";
+    const SCRIPT_VERSION = "1.24";
     const observers = [];
     let promptInputObserver = null;
     let dropdownObserver = null;
@@ -932,16 +932,6 @@
       container.appendChild(dropdown);
       wrapper.appendChild(container);
       colDiv.insertBefore(wrapper, colDiv.firstChild);
-      const actionBar = document.querySelector('[data-testid="composer-trailing-actions"]');
-      if (actionBar && !document.getElementById("gpt-history-action")) {
-        const historyBtn = document.createElement("button");
-        historyBtn.id = "gpt-history-action";
-        historyBtn.type = "button";
-        historyBtn.textContent = "History";
-        historyBtn.className = "btn relative btn-secondary btn-small";
-        historyBtn.addEventListener("click", () => openHistory());
-        actionBar.appendChild(historyBtn);
-      }
       dropdown.addEventListener("change", () => {
         const value = dropdown.value;
         if (!value) return;

--- a/openai-codex.user.js
+++ b/openai-codex.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.23
+// @version      1.24
 // @description  Adds a prompt suggestion dropdown above the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest
@@ -119,7 +119,7 @@
   // src/index.ts
   (function() {
     "use strict";
-    const SCRIPT_VERSION = "1.23";
+    const SCRIPT_VERSION = "1.24";
     const observers = [];
     let promptInputObserver = null;
     let dropdownObserver = null;
@@ -941,16 +941,6 @@
       container.appendChild(dropdown);
       wrapper.appendChild(container);
       colDiv.insertBefore(wrapper, colDiv.firstChild);
-      const actionBar = document.querySelector('[data-testid="composer-trailing-actions"]');
-      if (actionBar && !document.getElementById("gpt-history-action")) {
-        const historyBtn = document.createElement("button");
-        historyBtn.id = "gpt-history-action";
-        historyBtn.type = "button";
-        historyBtn.textContent = "History";
-        historyBtn.className = "btn relative btn-secondary btn-small";
-        historyBtn.addEventListener("click", () => openHistory());
-        actionBar.appendChild(historyBtn);
-      }
       dropdown.addEventListener("change", () => {
         const value = dropdown.value;
         if (!value) return;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.13",
+  "version": "1.0.14",
   "scripts": {
     "build": "node build.js",
     "test": "npm run build && node test.js"

--- a/src/header.js
+++ b/src/header.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.23
+// @version      1.24
 // @description  Adds a prompt suggestion dropdown above the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
 (function () {
 
     'use strict';
-    const SCRIPT_VERSION = '1.23';
+    const SCRIPT_VERSION = '1.24';
     const observers = [];
     let promptInputObserver = null;
     let dropdownObserver = null;
@@ -831,16 +831,8 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
         wrapper.appendChild(container);
         colDiv.insertBefore(wrapper, colDiv.firstChild);
 
-        const actionBar = document.querySelector('[data-testid="composer-trailing-actions"]');
-        if (actionBar && !document.getElementById('gpt-history-action')) {
-            const historyBtn = document.createElement('button');
-            historyBtn.id = 'gpt-history-action';
-            historyBtn.type = 'button';
-            historyBtn.textContent = 'History';
-            historyBtn.className = 'btn relative btn-secondary btn-small';
-            historyBtn.addEventListener('click', () => openHistory());
-            actionBar.appendChild(historyBtn);
-        }
+        // OpenAI Codex UI now includes a built-in history button. We no longer
+        // need to inject our custom one, so these lines were removed.
 
 
         dropdown.addEventListener('change', () => {


### PR DESCRIPTION
## Summary
- avoid injecting a custom history button now that Codex includes one
- bump version to 1.24

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687187ed547c8325a0f4f1ceb784cb5d