### PR TITLE
Improve sidebar icons and history display

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -118,7 +118,7 @@
   // src/index.ts
   (function() {
     "use strict";
-    const SCRIPT_VERSION = "1.0.19";
+    const SCRIPT_VERSION = "1.0.20";
     const observers = [];
     let promptInputObserver = null;
     let dropdownObserver = null;
@@ -200,10 +200,31 @@
     justify-content: center;
     cursor: pointer;
     box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+    position: relative;
 }
 #gpt-action-bar .gpt-action-btn:hover {
     background: var(--ring);
     color: var(--background);
+}
+#gpt-action-bar .gpt-action-btn::after {
+    content: attr(data-label);
+    position: absolute;
+    bottom: 120%;
+    left: 50%;
+    transform: translateX(-50%);
+    background: var(--background);
+    color: var(--foreground);
+    border: 1px solid var(--ring);
+    border-radius: 4px;
+    padding: 2px 4px;
+    font-size: 10px;
+    white-space: nowrap;
+    display: none;
+    pointer-events: none;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+}
+#gpt-action-bar .gpt-action-btn:hover::after {
+    display: block;
 }
 #gpt-settings-modal {
     position: fixed;
@@ -223,6 +244,8 @@
     padding: 1rem;
     max-width: 90%;
     width: 400px;
+    max-height: 80vh;
+    overflow-y: auto;
 }
 #gpt-settings-modal button {
     border: 1px solid var(--ring);
@@ -279,16 +302,16 @@
 #gpt-settings-modal .settings-group h3 { margin: 0 0 0.25rem 0; font-size: 1rem; }
 #gpt-history-modal { position: fixed; inset: 0; z-index: 1000; background: rgba(0,0,0,0.5); display: none; align-items: center; justify-content: center; }
 #gpt-history-modal.show { display: flex; }
-#gpt-history-modal .modal-content { background: var(--background); color: var(--foreground); border: 1px solid var(--ring); border-radius: 0.5rem; padding: 1rem; max-width: 90%; width: 400px; }
+#gpt-history-modal .modal-content { background: var(--background); color: var(--foreground); border: 1px solid var(--ring); border-radius: 0.5rem; padding: 1rem; max-width: 90%; width: 400px; max-height: 80vh; overflow-y: auto; }
 #gpt-history-modal button { border: 1px solid var(--ring); padding: 2px 6px; border-radius: 4px; }
 #gpt-repo-sidebar, #gpt-version-sidebar { position: fixed; inset-block-start: 10%; max-height: 80vh; width: 180px; background: var(--background); color: var(--foreground); border: 1px solid var(--ring); overflow-y: auto; z-index: 999; padding: 0.5rem; border-radius: 0.25rem; box-shadow: 0 2px 6px rgba(0,0,0,0.2); resize: both; }
 #gpt-repo-sidebar { inset-inline-start: 10px; }
 #gpt-version-sidebar { inset-inline-end: 10px; }
 #gpt-repo-sidebar.hidden, #gpt-version-sidebar.hidden { display: none; }
-#gpt-repo-handle, #gpt-version-handle { position: fixed; top: 50%; z-index: 998; background: var(--ring); color: var(--background); padding: 4px; cursor: pointer; user-select: none; }
+#gpt-repo-handle, #gpt-version-handle { position: fixed; top: 50%; z-index: 998; background: var(--background); color: var(--foreground); border: 1px solid var(--ring); width: 32px; height: 32px; border-radius: 9999px; display: flex; align-items: center; justify-content: center; cursor: pointer; user-select: none; transform: translateY(-50%); box-shadow: 0 2px 4px rgba(0,0,0,0.2); }
 #gpt-repo-sidebar > div:first-child, #gpt-version-sidebar > div:first-child { cursor: move; }
-#gpt-repo-handle { left: 0; border-radius: 0 4px 4px 0; transform: translate(0,-50%); }
-#gpt-version-handle { right: 0; border-radius: 4px 0 0 4px; transform: translate(0,-50%); }
+#gpt-repo-handle { left: 8px; }
+#gpt-version-handle { right: 8px; }
 #gpt-repo-handle.hidden, #gpt-version-handle.hidden { display: none; }
 `;
     document.head.appendChild(settingsStyle);
@@ -396,7 +419,7 @@
         repoRestoreBtn = document.createElement("button");
         repoRestoreBtn.id = "gpt-repo-restore";
         repoRestoreBtn.type = "button";
-        repoRestoreBtn.textContent = "Repos";
+        repoRestoreBtn.textContent = "\u{1F4C1}";
         repoRestoreBtn.className = "btn relative btn-secondary btn-small";
         repoRestoreBtn.addEventListener("click", () => {
           toggleRepoSidebar(true);
@@ -418,7 +441,7 @@
         versionRestoreBtn = document.createElement("button");
         versionRestoreBtn.id = "gpt-version-restore";
         versionRestoreBtn.type = "button";
-        versionRestoreBtn.textContent = "Versions";
+        versionRestoreBtn.textContent = "\u{1F516}";
         versionRestoreBtn.className = "btn relative btn-secondary btn-small";
         versionRestoreBtn.addEventListener("click", () => {
           toggleVersionSidebar(true);
@@ -519,21 +542,25 @@
     historyBtn.id = "gpt-history-btn";
     historyBtn.className = "gpt-action-btn";
     historyBtn.textContent = "\u{1F4DC}";
+    historyBtn.setAttribute("data-label", "History");
     actionBar.appendChild(historyBtn);
     const repoBtn = document.createElement("div");
     repoBtn.id = "gpt-repo-btn";
     repoBtn.className = "gpt-action-btn";
-    repoBtn.textContent = "Repos";
+    repoBtn.textContent = "\u{1F4C1}";
+    repoBtn.setAttribute("data-label", "Repos");
     actionBar.appendChild(repoBtn);
     const versionBtn = document.createElement("div");
     versionBtn.id = "gpt-version-btn";
     versionBtn.className = "gpt-action-btn";
-    versionBtn.textContent = "Versions";
+    versionBtn.textContent = "\u{1F516}";
+    versionBtn.setAttribute("data-label", "Versions");
     actionBar.appendChild(versionBtn);
     const settingsBtn = document.createElement("div");
     settingsBtn.id = "gpt-settings-btn";
     settingsBtn.className = "gpt-action-btn";
     settingsBtn.textContent = "\u2699\uFE0F";
+    settingsBtn.setAttribute("data-label", "Settings");
     actionBar.appendChild(settingsBtn);
     const modal = document.createElement("div");
     modal.id = "gpt-settings-modal";
@@ -627,7 +654,7 @@
     });
     const repoHandle = document.createElement("div");
     repoHandle.id = "gpt-repo-handle";
-    repoHandle.textContent = "Repos";
+    repoHandle.textContent = "\u{1F4C1}";
     document.body.appendChild(repoHandle);
     repoHandle.addEventListener("click", () => {
       toggleRepoSidebar(true);
@@ -636,7 +663,7 @@
     });
     const versionHandle = document.createElement("div");
     versionHandle.id = "gpt-version-handle";
-    versionHandle.textContent = "Versions";
+    versionHandle.textContent = "\u{1F516}";
     document.body.appendChild(versionHandle);
     versionHandle.addEventListener("click", () => {
       toggleVersionSidebar(true);
@@ -837,7 +864,8 @@
       history.forEach((h, i) => {
         const li = document.createElement("li");
         const span = document.createElement("span");
-        span.textContent = h.split(/\r?\n/)[0];
+        const first = h.split(/\r?\n/)[0];
+        span.textContent = first.length > 30 ? first.slice(0, 30) + "\u2026" : first;
         li.appendChild(span);
         const useBtn = document.createElement("button");
         useBtn.className = "btn relative btn-secondary btn-small";

--- a/openai-codex.user.js
+++ b/openai-codex.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.0.19
+// @version      1.0.20
 // @description  Adds a prompt suggestion dropdown above the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest
@@ -127,7 +127,7 @@
   // src/index.ts
   (function() {
     "use strict";
-    const SCRIPT_VERSION = "1.0.19";
+    const SCRIPT_VERSION = "1.0.20";
     const observers = [];
     let promptInputObserver = null;
     let dropdownObserver = null;
@@ -209,10 +209,31 @@
     justify-content: center;
     cursor: pointer;
     box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+    position: relative;
 }
 #gpt-action-bar .gpt-action-btn:hover {
     background: var(--ring);
     color: var(--background);
+}
+#gpt-action-bar .gpt-action-btn::after {
+    content: attr(data-label);
+    position: absolute;
+    bottom: 120%;
+    left: 50%;
+    transform: translateX(-50%);
+    background: var(--background);
+    color: var(--foreground);
+    border: 1px solid var(--ring);
+    border-radius: 4px;
+    padding: 2px 4px;
+    font-size: 10px;
+    white-space: nowrap;
+    display: none;
+    pointer-events: none;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+}
+#gpt-action-bar .gpt-action-btn:hover::after {
+    display: block;
 }
 #gpt-settings-modal {
     position: fixed;
@@ -232,6 +253,8 @@
     padding: 1rem;
     max-width: 90%;
     width: 400px;
+    max-height: 80vh;
+    overflow-y: auto;
 }
 #gpt-settings-modal button {
     border: 1px solid var(--ring);
@@ -288,16 +311,16 @@
 #gpt-settings-modal .settings-group h3 { margin: 0 0 0.25rem 0; font-size: 1rem; }
 #gpt-history-modal { position: fixed; inset: 0; z-index: 1000; background: rgba(0,0,0,0.5); display: none; align-items: center; justify-content: center; }
 #gpt-history-modal.show { display: flex; }
-#gpt-history-modal .modal-content { background: var(--background); color: var(--foreground); border: 1px solid var(--ring); border-radius: 0.5rem; padding: 1rem; max-width: 90%; width: 400px; }
+#gpt-history-modal .modal-content { background: var(--background); color: var(--foreground); border: 1px solid var(--ring); border-radius: 0.5rem; padding: 1rem; max-width: 90%; width: 400px; max-height: 80vh; overflow-y: auto; }
 #gpt-history-modal button { border: 1px solid var(--ring); padding: 2px 6px; border-radius: 4px; }
 #gpt-repo-sidebar, #gpt-version-sidebar { position: fixed; inset-block-start: 10%; max-height: 80vh; width: 180px; background: var(--background); color: var(--foreground); border: 1px solid var(--ring); overflow-y: auto; z-index: 999; padding: 0.5rem; border-radius: 0.25rem; box-shadow: 0 2px 6px rgba(0,0,0,0.2); resize: both; }
 #gpt-repo-sidebar { inset-inline-start: 10px; }
 #gpt-version-sidebar { inset-inline-end: 10px; }
 #gpt-repo-sidebar.hidden, #gpt-version-sidebar.hidden { display: none; }
-#gpt-repo-handle, #gpt-version-handle { position: fixed; top: 50%; z-index: 998; background: var(--ring); color: var(--background); padding: 4px; cursor: pointer; user-select: none; }
+#gpt-repo-handle, #gpt-version-handle { position: fixed; top: 50%; z-index: 998; background: var(--background); color: var(--foreground); border: 1px solid var(--ring); width: 32px; height: 32px; border-radius: 9999px; display: flex; align-items: center; justify-content: center; cursor: pointer; user-select: none; transform: translateY(-50%); box-shadow: 0 2px 4px rgba(0,0,0,0.2); }
 #gpt-repo-sidebar > div:first-child, #gpt-version-sidebar > div:first-child { cursor: move; }
-#gpt-repo-handle { left: 0; border-radius: 0 4px 4px 0; transform: translate(0,-50%); }
-#gpt-version-handle { right: 0; border-radius: 4px 0 0 4px; transform: translate(0,-50%); }
+#gpt-repo-handle { left: 8px; }
+#gpt-version-handle { right: 8px; }
 #gpt-repo-handle.hidden, #gpt-version-handle.hidden { display: none; }
 `;
     document.head.appendChild(settingsStyle);
@@ -405,7 +428,7 @@
         repoRestoreBtn = document.createElement("button");
         repoRestoreBtn.id = "gpt-repo-restore";
         repoRestoreBtn.type = "button";
-        repoRestoreBtn.textContent = "Repos";
+        repoRestoreBtn.textContent = "\u{1F4C1}";
         repoRestoreBtn.className = "btn relative btn-secondary btn-small";
         repoRestoreBtn.addEventListener("click", () => {
           toggleRepoSidebar(true);
@@ -427,7 +450,7 @@
         versionRestoreBtn = document.createElement("button");
         versionRestoreBtn.id = "gpt-version-restore";
         versionRestoreBtn.type = "button";
-        versionRestoreBtn.textContent = "Versions";
+        versionRestoreBtn.textContent = "\u{1F516}";
         versionRestoreBtn.className = "btn relative btn-secondary btn-small";
         versionRestoreBtn.addEventListener("click", () => {
           toggleVersionSidebar(true);
@@ -528,21 +551,25 @@
     historyBtn.id = "gpt-history-btn";
     historyBtn.className = "gpt-action-btn";
     historyBtn.textContent = "\u{1F4DC}";
+    historyBtn.setAttribute("data-label", "History");
     actionBar.appendChild(historyBtn);
     const repoBtn = document.createElement("div");
     repoBtn.id = "gpt-repo-btn";
     repoBtn.className = "gpt-action-btn";
-    repoBtn.textContent = "Repos";
+    repoBtn.textContent = "\u{1F4C1}";
+    repoBtn.setAttribute("data-label", "Repos");
     actionBar.appendChild(repoBtn);
     const versionBtn = document.createElement("div");
     versionBtn.id = "gpt-version-btn";
     versionBtn.className = "gpt-action-btn";
-    versionBtn.textContent = "Versions";
+    versionBtn.textContent = "\u{1F516}";
+    versionBtn.setAttribute("data-label", "Versions");
     actionBar.appendChild(versionBtn);
     const settingsBtn = document.createElement("div");
     settingsBtn.id = "gpt-settings-btn";
     settingsBtn.className = "gpt-action-btn";
     settingsBtn.textContent = "\u2699\uFE0F";
+    settingsBtn.setAttribute("data-label", "Settings");
     actionBar.appendChild(settingsBtn);
     const modal = document.createElement("div");
     modal.id = "gpt-settings-modal";
@@ -636,7 +663,7 @@
     });
     const repoHandle = document.createElement("div");
     repoHandle.id = "gpt-repo-handle";
-    repoHandle.textContent = "Repos";
+    repoHandle.textContent = "\u{1F4C1}";
     document.body.appendChild(repoHandle);
     repoHandle.addEventListener("click", () => {
       toggleRepoSidebar(true);
@@ -645,7 +672,7 @@
     });
     const versionHandle = document.createElement("div");
     versionHandle.id = "gpt-version-handle";
-    versionHandle.textContent = "Versions";
+    versionHandle.textContent = "\u{1F516}";
     document.body.appendChild(versionHandle);
     versionHandle.addEventListener("click", () => {
       toggleVersionSidebar(true);
@@ -846,7 +873,8 @@
       history.forEach((h, i) => {
         const li = document.createElement("li");
         const span = document.createElement("span");
-        span.textContent = h.split(/\r?\n/)[0];
+        const first = h.split(/\r?\n/)[0];
+        span.textContent = first.length > 30 ? first.slice(0, 30) + "\u2026" : first;
         li.appendChild(span);
         const useBtn = document.createElement("button");
         useBtn.className = "btn relative btn-secondary btn-small";

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.19",
+  "version": "1.0.20",
   "scripts": {
     "build": "node build.js",
     "test": "npm run build && node test.js"

--- a/src/header.js
+++ b/src/header.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.0.19
+// @version      1.0.20
 // @description  Adds a prompt suggestion dropdown above the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
 (function () {
 
     'use strict';
-    const SCRIPT_VERSION = '1.0.19';
+    const SCRIPT_VERSION = '1.0.20';
     const observers = [];
     let promptInputObserver = null;
     let dropdownObserver = null;
@@ -92,10 +92,31 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
     justify-content: center;
     cursor: pointer;
     box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+    position: relative;
 }
 #gpt-action-bar .gpt-action-btn:hover {
     background: var(--ring);
     color: var(--background);
+}
+#gpt-action-bar .gpt-action-btn::after {
+    content: attr(data-label);
+    position: absolute;
+    bottom: 120%;
+    left: 50%;
+    transform: translateX(-50%);
+    background: var(--background);
+    color: var(--foreground);
+    border: 1px solid var(--ring);
+    border-radius: 4px;
+    padding: 2px 4px;
+    font-size: 10px;
+    white-space: nowrap;
+    display: none;
+    pointer-events: none;
+    box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+}
+#gpt-action-bar .gpt-action-btn:hover::after {
+    display: block;
 }
 #gpt-settings-modal {
     position: fixed;
@@ -115,6 +136,8 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
     padding: 1rem;
     max-width: 90%;
     width: 400px;
+    max-height: 80vh;
+    overflow-y: auto;
 }
 #gpt-settings-modal button {
     border: 1px solid var(--ring);
@@ -171,16 +194,16 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
 #gpt-settings-modal .settings-group h3 { margin: 0 0 0.25rem 0; font-size: 1rem; }
 #gpt-history-modal { position: fixed; inset: 0; z-index: 1000; background: rgba(0,0,0,0.5); display: none; align-items: center; justify-content: center; }
 #gpt-history-modal.show { display: flex; }
-#gpt-history-modal .modal-content { background: var(--background); color: var(--foreground); border: 1px solid var(--ring); border-radius: 0.5rem; padding: 1rem; max-width: 90%; width: 400px; }
+#gpt-history-modal .modal-content { background: var(--background); color: var(--foreground); border: 1px solid var(--ring); border-radius: 0.5rem; padding: 1rem; max-width: 90%; width: 400px; max-height: 80vh; overflow-y: auto; }
 #gpt-history-modal button { border: 1px solid var(--ring); padding: 2px 6px; border-radius: 4px; }
 #gpt-repo-sidebar, #gpt-version-sidebar { position: fixed; inset-block-start: 10%; max-height: 80vh; width: 180px; background: var(--background); color: var(--foreground); border: 1px solid var(--ring); overflow-y: auto; z-index: 999; padding: 0.5rem; border-radius: 0.25rem; box-shadow: 0 2px 6px rgba(0,0,0,0.2); resize: both; }
 #gpt-repo-sidebar { inset-inline-start: 10px; }
 #gpt-version-sidebar { inset-inline-end: 10px; }
 #gpt-repo-sidebar.hidden, #gpt-version-sidebar.hidden { display: none; }
-#gpt-repo-handle, #gpt-version-handle { position: fixed; top: 50%; z-index: 998; background: var(--ring); color: var(--background); padding: 4px; cursor: pointer; user-select: none; }
+#gpt-repo-handle, #gpt-version-handle { position: fixed; top: 50%; z-index: 998; background: var(--background); color: var(--foreground); border: 1px solid var(--ring); width: 32px; height: 32px; border-radius: 9999px; display: flex; align-items: center; justify-content: center; cursor: pointer; user-select: none; transform: translateY(-50%); box-shadow: 0 2px 4px rgba(0,0,0,0.2); }
 #gpt-repo-sidebar > div:first-child, #gpt-version-sidebar > div:first-child { cursor: move; }
-#gpt-repo-handle { left: 0; border-radius: 0 4px 4px 0; transform: translate(0,-50%); }
-#gpt-version-handle { right: 0; border-radius: 4px 0 0 4px; transform: translate(0,-50%); }
+#gpt-repo-handle { left: 8px; }
+#gpt-version-handle { right: 8px; }
 #gpt-repo-handle.hidden, #gpt-version-handle.hidden { display: none; }
 `;
     document.head.appendChild(settingsStyle);
@@ -306,7 +329,7 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
             repoRestoreBtn = document.createElement('button');
             repoRestoreBtn.id = 'gpt-repo-restore';
             repoRestoreBtn.type = 'button';
-            repoRestoreBtn.textContent = 'Repos';
+            repoRestoreBtn.textContent = '📁';
             repoRestoreBtn.className = 'btn relative btn-secondary btn-small';
             repoRestoreBtn.addEventListener('click', () => {
                 toggleRepoSidebar(true);
@@ -329,7 +352,7 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
             versionRestoreBtn = document.createElement('button');
             versionRestoreBtn.id = 'gpt-version-restore';
             versionRestoreBtn.type = 'button';
-            versionRestoreBtn.textContent = 'Versions';
+            versionRestoreBtn.textContent = '🔖';
             versionRestoreBtn.className = 'btn relative btn-secondary btn-small';
             versionRestoreBtn.addEventListener('click', () => {
                 toggleVersionSidebar(true);
@@ -435,24 +458,28 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
     historyBtn.id = 'gpt-history-btn';
     historyBtn.className = 'gpt-action-btn';
     historyBtn.textContent = '📜';
+    historyBtn.setAttribute('data-label', 'History');
     actionBar.appendChild(historyBtn);
 
     const repoBtn = document.createElement('div');
     repoBtn.id = 'gpt-repo-btn';
     repoBtn.className = 'gpt-action-btn';
-    repoBtn.textContent = 'Repos';
+    repoBtn.textContent = '📁';
+    repoBtn.setAttribute('data-label', 'Repos');
     actionBar.appendChild(repoBtn);
 
     const versionBtn = document.createElement('div');
     versionBtn.id = 'gpt-version-btn';
     versionBtn.className = 'gpt-action-btn';
-    versionBtn.textContent = 'Versions';
+    versionBtn.textContent = '🔖';
+    versionBtn.setAttribute('data-label', 'Versions');
     actionBar.appendChild(versionBtn);
 
     const settingsBtn = document.createElement('div');
     settingsBtn.id = 'gpt-settings-btn';
     settingsBtn.className = 'gpt-action-btn';
     settingsBtn.textContent = '⚙️';
+    settingsBtn.setAttribute('data-label', 'Settings');
     actionBar.appendChild(settingsBtn);
 
     const modal = document.createElement('div');
@@ -551,7 +578,7 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
 
     const repoHandle = document.createElement('div');
     repoHandle.id = 'gpt-repo-handle';
-    repoHandle.textContent = 'Repos';
+    repoHandle.textContent = '📁';
     document.body.appendChild(repoHandle);
     repoHandle.addEventListener('click', () => {
         toggleRepoSidebar(true);
@@ -561,7 +588,7 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
 
     const versionHandle = document.createElement('div');
     versionHandle.id = 'gpt-version-handle';
-    versionHandle.textContent = 'Versions';
+    versionHandle.textContent = '🔖';
     document.body.appendChild(versionHandle);
     versionHandle.addEventListener('click', () => {
         toggleVersionSidebar(true);
@@ -777,7 +804,8 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
         history.forEach((h, i) => {
             const li = document.createElement('li');
             const span = document.createElement('span');
-            span.textContent = h.split(/\r?\n/)[0];
+            const first = h.split(/\r?\n/)[0];
+            span.textContent = first.length > 30 ? first.slice(0, 30) + '…' : first;
             li.appendChild(span);
 
             const useBtn = document.createElement('button');


### PR DESCRIPTION
## Summary
- switch to icon-based handles for repository and version sidebars
- show labels on action bar buttons when hovering
- constrain settings and history dialogs to viewport height
- truncate long history entries and keep a use button
- bump version to 1.0.20

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874206388548325a0552616584b5adb