### PR TITLE
Improve sidebar controls

### DIFF
--- a/openai-codex.user.js
+++ b/openai-codex.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.0.20
+// @version      1.0.21
 // @description  Adds a prompt suggestion dropdown above the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest
@@ -127,14 +127,12 @@
   // src/index.ts
   (function() {
     "use strict";
-    const SCRIPT_VERSION = "1.0.20";
+    const SCRIPT_VERSION = "1.0.21";
     const observers = [];
     let promptInputObserver = null;
     let dropdownObserver = null;
     let currentPromptDiv = null;
     let currentColDiv = null;
-    let repoRestoreBtn = null;
-    let versionRestoreBtn = null;
     const THEME_TOKENS = {
       light: {
         "--brand-purple": "#824dff"
@@ -416,49 +414,55 @@
       }
       el.addEventListener("mouseup", () => savePos());
     }
+    function ensureSidebarInBounds(el, prefix) {
+      const rect = el.getBoundingClientRect();
+      const margin = 10;
+      let left = rect.left;
+      let top = rect.top;
+      const maxX = window.innerWidth - rect.width - margin;
+      const maxY = window.innerHeight - rect.height - margin;
+      let changed = false;
+      if (left < margin) {
+        left = margin;
+        changed = true;
+      }
+      if (left > maxX) {
+        left = maxX;
+        changed = true;
+      }
+      if (top < margin) {
+        top = margin;
+        changed = true;
+      }
+      if (top > maxY) {
+        top = maxY;
+        changed = true;
+      }
+      if (changed) {
+        el.style.left = left + "px";
+        el.style.top = top + "px";
+        options[prefix + "X"] = left;
+        options[prefix + "Y"] = top;
+        saveOptions(options);
+      }
+    }
     function toggleRepoSidebar(show) {
       const el = document.getElementById("gpt-repo-sidebar");
       const handle = document.getElementById("gpt-repo-handle");
-      const actionBar2 = document.querySelector('[data-testid="composer-trailing-actions"]');
-      if (el) el.classList.toggle("hidden", !show);
-      if (handle) handle.classList.toggle("hidden", show);
-      if (show) {
-        if (repoRestoreBtn) repoRestoreBtn.remove();
-      } else if (actionBar2 && !repoRestoreBtn) {
-        repoRestoreBtn = document.createElement("button");
-        repoRestoreBtn.id = "gpt-repo-restore";
-        repoRestoreBtn.type = "button";
-        repoRestoreBtn.textContent = "\u{1F4C1}";
-        repoRestoreBtn.className = "btn relative btn-secondary btn-small";
-        repoRestoreBtn.addEventListener("click", () => {
-          toggleRepoSidebar(true);
-          options.showRepoSidebar = true;
-          saveOptions(options);
-        });
-        actionBar2.appendChild(repoRestoreBtn);
+      if (el) {
+        el.classList.toggle("hidden", !show);
+        if (show) ensureSidebarInBounds(el, "repoSidebar");
       }
+      if (handle) handle.classList.toggle("hidden", show);
     }
     function toggleVersionSidebar(show) {
       const el = document.getElementById("gpt-version-sidebar");
       const handle = document.getElementById("gpt-version-handle");
-      const actionBar2 = document.querySelector('[data-testid="composer-trailing-actions"]');
-      if (el) el.classList.toggle("hidden", !show);
-      if (handle) handle.classList.toggle("hidden", show);
-      if (show) {
-        if (versionRestoreBtn) versionRestoreBtn.remove();
-      } else if (actionBar2 && !versionRestoreBtn) {
-        versionRestoreBtn = document.createElement("button");
-        versionRestoreBtn.id = "gpt-version-restore";
-        versionRestoreBtn.type = "button";
-        versionRestoreBtn.textContent = "\u{1F516}";
-        versionRestoreBtn.className = "btn relative btn-secondary btn-small";
-        versionRestoreBtn.addEventListener("click", () => {
-          toggleVersionSidebar(true);
-          options.showVersionSidebar = true;
-          saveOptions(options);
-        });
-        actionBar2.appendChild(versionRestoreBtn);
+      if (el) {
+        el.classList.toggle("hidden", !show);
+        if (show) ensureSidebarInBounds(el, "versionSidebar");
       }
+      if (handle) handle.classList.toggle("hidden", show);
     }
     function applyOptions() {
       const root = document.documentElement;
@@ -500,6 +504,7 @@
         if (options.repoSidebarY !== null) repoEl.style.top = options.repoSidebarY + "px";
         if (options.repoSidebarWidth !== null) repoEl.style.width = options.repoSidebarWidth + "px";
         if (options.repoSidebarHeight !== null) repoEl.style.height = options.repoSidebarHeight + "px";
+        ensureSidebarInBounds(repoEl, "repoSidebar");
       }
       const verEl = document.getElementById("gpt-version-sidebar");
       if (verEl) {
@@ -507,6 +512,7 @@
         if (options.versionSidebarY !== null) verEl.style.top = options.versionSidebarY + "px";
         if (options.versionSidebarWidth !== null) verEl.style.width = options.versionSidebarWidth + "px";
         if (options.versionSidebarHeight !== null) verEl.style.height = options.versionSidebarHeight + "px";
+        ensureSidebarInBounds(verEl, "versionSidebar");
       }
     }
     async function checkForUpdates() {
@@ -628,7 +634,9 @@
             <label><input type="checkbox" id="gpt-setting-disable-history"> Disable prompt history</label><br>
             <label>History limit <input type="number" id="gpt-setting-history-limit" min="1" style="width:4rem"></label>
         </div>
-        <button id="gpt-update-check" class="btn btn-primary btn-small">Check for Updates</button><br>
+        <button id="gpt-update-check" class="btn btn-primary btn-small">Check for Updates</button>
+        <button id="gpt-reset-defaults" class="btn btn-secondary btn-small">Reset Defaults</button>
+        <button id="gpt-reset-windows" class="btn btn-secondary btn-small">Reset Windows</button><br>
         <div class="mt-2 text-right"><button id="gpt-settings-close" class="btn btn-secondary btn-small">Close</button></div>
     </div>`;
     document.body.appendChild(modal);
@@ -910,13 +918,17 @@
     }
     historyBtn.addEventListener("click", openHistory);
     repoBtn.addEventListener("click", () => {
-      toggleRepoSidebar(true);
-      options.showRepoSidebar = true;
+      const el = document.getElementById("gpt-repo-sidebar");
+      const show = !el || el.classList.contains("hidden");
+      toggleRepoSidebar(show);
+      options.showRepoSidebar = show;
       saveOptions(options);
     });
     versionBtn.addEventListener("click", () => {
-      toggleVersionSidebar(true);
-      options.showVersionSidebar = true;
+      const el = document.getElementById("gpt-version-sidebar");
+      const show = !el || el.classList.contains("hidden");
+      toggleVersionSidebar(show);
+      options.showVersionSidebar = show;
       saveOptions(options);
     });
     settingsBtn.addEventListener("click", openSettings);
@@ -1021,6 +1033,18 @@
       saveOptions(options);
     });
     modal.querySelector("#gpt-update-check").addEventListener("click", () => checkForUpdates());
+    modal.querySelector("#gpt-reset-defaults").addEventListener("click", () => {
+      options = __spreadValues({}, DEFAULT_OPTIONS);
+      saveOptions(options);
+      applyOptions();
+      openSettings();
+    });
+    modal.querySelector("#gpt-reset-windows").addEventListener("click", () => {
+      options.repoSidebarX = options.repoSidebarY = options.repoSidebarWidth = options.repoSidebarHeight = null;
+      options.versionSidebarX = options.versionSidebarY = options.versionSidebarWidth = options.versionSidebarHeight = null;
+      saveOptions(options);
+      applyOptions();
+    });
     const pageObserver = new MutationObserver(() => {
       toggleHeader(options.hideHeader);
       toggleDocs(options.hideDocs);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.20",
+  "version": "1.0.21",
   "scripts": {
     "build": "node build.js",
     "test": "npm run build && node test.js"

--- a/src/header.js
+++ b/src/header.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.0.20
+// @version      1.0.21
 // @description  Adds a prompt suggestion dropdown above the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest


### PR DESCRIPTION
## Summary
- update version to 1.0.21
- add boundary checks when restoring sidebar positions
- toggle sidebars via action bar buttons
- add buttons to reset options and window positions
- ensure repo/version windows stay onscreen

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687500e69a38832595681f365531ae8d