### PR TITLE
Add suggestions import/export support

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -929,6 +929,59 @@
             }
           });
           wrap.appendChild(addBtn);
+          const exportBtn = document.createElement("button");
+          exportBtn.className = "btn relative btn-secondary btn-small";
+          exportBtn.textContent = "Export";
+          exportBtn.addEventListener("click", () => {
+            try {
+              const blob = new Blob([JSON.stringify(suggestions, null, 2)], { type: "application/json" });
+              const url = URL.createObjectURL(blob);
+              const a = document.createElement("a");
+              a.href = url;
+              a.download = "suggestions.json";
+              document.body.appendChild(a);
+              a.click();
+              URL.revokeObjectURL(url);
+              a.remove();
+            } catch (e) {
+              console.error("Failed to export suggestions", e);
+              window.alert("Failed to export suggestions");
+            }
+          });
+          wrap.appendChild(exportBtn);
+          const importBtn = document.createElement("button");
+          importBtn.className = "btn relative btn-secondary btn-small";
+          importBtn.textContent = "Import";
+          importBtn.addEventListener("click", () => {
+            const input = document.createElement("input");
+            input.type = "file";
+            input.accept = "application/json";
+            input.addEventListener("change", () => {
+              var _a;
+              const file = (_a = input.files) == null ? void 0 : _a[0];
+              if (!file) return;
+              const reader = new FileReader();
+              reader.onload = () => {
+                try {
+                  const data = JSON.parse(String(reader.result));
+                  if (Array.isArray(data) && data.every((d) => typeof d === "string")) {
+                    suggestions = data.map((d) => String(d).trim());
+                    saveSuggestions(suggestions);
+                    renderSuggestions();
+                    refreshDropdown();
+                  } else {
+                    window.alert("Invalid suggestions file");
+                  }
+                } catch (err) {
+                  console.error("Failed to import suggestions", err);
+                  window.alert("Failed to import suggestions");
+                }
+              };
+              reader.readAsText(file);
+            });
+            input.click();
+          });
+          wrap.appendChild(importBtn);
         }
         function openSettings() {
           renderSuggestions();

--- a/openai-codex.user.js
+++ b/openai-codex.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.0.26
+// @version      1.0.27
 // @description  Adds a prompt suggestion dropdown above the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest
@@ -938,6 +938,59 @@
             }
           });
           wrap.appendChild(addBtn);
+          const exportBtn = document.createElement("button");
+          exportBtn.className = "btn relative btn-secondary btn-small";
+          exportBtn.textContent = "Export";
+          exportBtn.addEventListener("click", () => {
+            try {
+              const blob = new Blob([JSON.stringify(suggestions, null, 2)], { type: "application/json" });
+              const url = URL.createObjectURL(blob);
+              const a = document.createElement("a");
+              a.href = url;
+              a.download = "suggestions.json";
+              document.body.appendChild(a);
+              a.click();
+              URL.revokeObjectURL(url);
+              a.remove();
+            } catch (e) {
+              console.error("Failed to export suggestions", e);
+              window.alert("Failed to export suggestions");
+            }
+          });
+          wrap.appendChild(exportBtn);
+          const importBtn = document.createElement("button");
+          importBtn.className = "btn relative btn-secondary btn-small";
+          importBtn.textContent = "Import";
+          importBtn.addEventListener("click", () => {
+            const input = document.createElement("input");
+            input.type = "file";
+            input.accept = "application/json";
+            input.addEventListener("change", () => {
+              var _a;
+              const file = (_a = input.files) == null ? void 0 : _a[0];
+              if (!file) return;
+              const reader = new FileReader();
+              reader.onload = () => {
+                try {
+                  const data = JSON.parse(String(reader.result));
+                  if (Array.isArray(data) && data.every((d) => typeof d === "string")) {
+                    suggestions = data.map((d) => String(d).trim());
+                    saveSuggestions(suggestions);
+                    renderSuggestions();
+                    refreshDropdown();
+                  } else {
+                    window.alert("Invalid suggestions file");
+                  }
+                } catch (err) {
+                  console.error("Failed to import suggestions", err);
+                  window.alert("Failed to import suggestions");
+                }
+              };
+              reader.readAsText(file);
+            });
+            input.click();
+          });
+          wrap.appendChild(importBtn);
         }
         function openSettings() {
           renderSuggestions();

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openai-codex-userscript",
-      "version": "1.0.26",
+      "version": "1.0.27",
       "license": "ISC",
       "devDependencies": {
         "esbuild": "^0.25.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.26",
+  "version": "1.0.27",
   "scripts": {
     "build": "node build.js",
     "test": "npm run build && node test.js"

--- a/src/header.js
+++ b/src/header.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.0.26
+// @version      1.0.27
 // @description  Adds a prompt suggestion dropdown above the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest

--- a/src/index.ts
+++ b/src/index.ts
@@ -825,6 +825,60 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
             }
         });
         wrap.appendChild(addBtn);
+
+        const exportBtn = document.createElement('button');
+        exportBtn.className = 'btn relative btn-secondary btn-small';
+        exportBtn.textContent = 'Export';
+        exportBtn.addEventListener('click', () => {
+            try {
+                const blob = new Blob([JSON.stringify(suggestions, null, 2)], { type: 'application/json' });
+                const url = URL.createObjectURL(blob);
+                const a = document.createElement('a');
+                a.href = url;
+                a.download = 'suggestions.json';
+                document.body.appendChild(a);
+                a.click();
+                URL.revokeObjectURL(url);
+                a.remove();
+            } catch (e) {
+                console.error('Failed to export suggestions', e);
+                window.alert('Failed to export suggestions');
+            }
+        });
+        wrap.appendChild(exportBtn);
+
+        const importBtn = document.createElement('button');
+        importBtn.className = 'btn relative btn-secondary btn-small';
+        importBtn.textContent = 'Import';
+        importBtn.addEventListener('click', () => {
+            const input = document.createElement('input');
+            input.type = 'file';
+            input.accept = 'application/json';
+            input.addEventListener('change', () => {
+                const file = input.files?.[0];
+                if (!file) return;
+                const reader = new FileReader();
+                reader.onload = () => {
+                    try {
+                        const data = JSON.parse(String(reader.result));
+                        if (Array.isArray(data) && data.every(d => typeof d === 'string')) {
+                            suggestions = data.map(d => String(d).trim());
+                            saveSuggestions(suggestions);
+                            renderSuggestions();
+                            refreshDropdown();
+                        } else {
+                            window.alert('Invalid suggestions file');
+                        }
+                    } catch (err) {
+                        console.error('Failed to import suggestions', err);
+                        window.alert('Failed to import suggestions');
+                    }
+                };
+                reader.readAsText(file);
+            });
+            input.click();
+        });
+        wrap.appendChild(importBtn);
     }
 
     function openSettings() {


### PR DESCRIPTION
## Summary
- add Import/Export buttons to suggestions management UI
- persist imported suggestions and refresh dropdown
- bump version to 1.0.27

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687536b55e088325859a6ff075dbc0e1