### PR TITLE
Add history search filter

### DIFF
--- a/openai-codex.user.js
+++ b/openai-codex.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.0.27
+// @version      1.0.28
 // @description  Adds a prompt suggestion dropdown above the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest
@@ -162,7 +162,7 @@
       init_history();
       (function() {
         "use strict";
-        const SCRIPT_VERSION = "1.0.26";
+        const SCRIPT_VERSION = "1.0.28";
         const observers = [];
         let promptInputObserver = null;
         let dropdownObserver = null;
@@ -346,6 +346,14 @@
 #gpt-history-modal.show { display: flex; }
 #gpt-history-modal .modal-content { background: var(--background); color: var(--foreground); border: 1px solid var(--ring); border-radius: 0.5rem; padding: 1rem; max-width: 90%; width: 400px; max-height: 80vh; overflow-y: auto; }
 #gpt-history-modal button { border: 1px solid var(--ring); padding: 2px 6px; border-radius: 4px; }
+#gpt-history-search {
+    border: 1px solid var(--ring);
+    background: var(--background);
+    color: var(--foreground);
+    border-radius: 4px;
+    padding: 2px 4px;
+    width: 100%;
+}
 #gpt-history-preview { position: fixed; inset: 0; z-index: 1000; background: rgba(0,0,0,0.5); display: none; align-items: center; justify-content: center; }
 #gpt-history-preview.show { display: flex; }
 #gpt-history-preview .modal-content { background: var(--background); color: var(--foreground); border: 1px solid var(--ring); border-radius: 0.5rem; padding: 1rem; max-width: 90%; width: 400px; max-height: 80vh; overflow-y: auto; }
@@ -373,6 +381,7 @@
         let suggestions = loadSuggestions() || DEFAULT_SUGGESTIONS.slice();
         let options = loadOptions();
         let history = loadHistory();
+        let historyQuery = "";
         function findByText(text) {
           const elements = Array.from(document.querySelectorAll("body *"));
           return elements.find((el) => el.textContent && el.textContent.includes(text)) || null;
@@ -676,6 +685,7 @@
         historyModal.innerHTML = `
     <div class="modal-content">
         <h2 class="mb-2 text-lg">Prompt History</h2>
+        <input type="text" id="gpt-history-search" class="w-full mb-2" placeholder="Search...">
         <div id="gpt-history-list"></div>
         <div class="mt-2 text-right"><button id="gpt-history-clear" class="btn btn-secondary btn-small">Clear</button> <button id="gpt-history-close" class="btn btn-secondary btn-small">Close</button></div>
     </div>`;
@@ -1022,11 +1032,19 @@
           modal.querySelector("#gpt-setting-auto-archive-closed").checked = options.autoArchiveClosed;
           modal.classList.add("show");
         }
+        function filterHistory(list, query) {
+          const q = (query || "").toLowerCase();
+          return list.reduce((acc, h, i) => {
+            if (!q || h.toLowerCase().includes(q)) acc.push([h, i]);
+            return acc;
+          }, []);
+        }
         function renderHistory() {
           const wrap = historyModal.querySelector("#gpt-history-list");
           wrap.innerHTML = "";
           const ul = document.createElement("ul");
-          history.forEach((h, i) => {
+          const items = filterHistory(history, historyQuery);
+          items.forEach(([h, i]) => {
             const li = document.createElement("li");
             const span = document.createElement("span");
             const first = h.split(/\r?\n/)[0];
@@ -1060,6 +1078,8 @@
           wrap.appendChild(ul);
         }
         function openHistory() {
+          const input = historyModal.querySelector("#gpt-history-search");
+          if (input) input.value = historyQuery;
           renderHistory();
           historyModal.classList.add("show");
         }
@@ -1090,6 +1110,11 @@
         historyModal.querySelector("#gpt-history-clear").addEventListener("click", () => {
           history = [];
           saveHistory(history);
+          renderHistory();
+        });
+        const historySearchInput = historyModal.querySelector("#gpt-history-search");
+        historySearchInput == null ? void 0 : historySearchInput.addEventListener("input", () => {
+          historyQuery = historySearchInput.value;
           renderHistory();
         });
         modal.querySelector("#gpt-setting-theme").addEventListener("change", (e) => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openai-codex-userscript",
-      "version": "1.0.27",
+      "version": "1.0.28",
       "license": "ISC",
       "devDependencies": {
         "esbuild": "^0.25.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.27",
+  "version": "1.0.28",
   "scripts": {
     "build": "node build.js",
     "test": "npm run build && node test.js"

--- a/src/header.js
+++ b/src/header.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.0.27
+// @version      1.0.28
 // @description  Adds a prompt suggestion dropdown above the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,7 +6,7 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
 (function () {
 
     'use strict';
-    const SCRIPT_VERSION = '1.0.26';
+    const SCRIPT_VERSION = '1.0.28';
     const observers = [];
     let promptInputObserver = null;
     let dropdownObserver = null;
@@ -194,6 +194,14 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
 #gpt-history-modal.show { display: flex; }
 #gpt-history-modal .modal-content { background: var(--background); color: var(--foreground); border: 1px solid var(--ring); border-radius: 0.5rem; padding: 1rem; max-width: 90%; width: 400px; max-height: 80vh; overflow-y: auto; }
 #gpt-history-modal button { border: 1px solid var(--ring); padding: 2px 6px; border-radius: 4px; }
+#gpt-history-search {
+    border: 1px solid var(--ring);
+    background: var(--background);
+    color: var(--foreground);
+    border-radius: 4px;
+    padding: 2px 4px;
+    width: 100%;
+}
 #gpt-history-preview { position: fixed; inset: 0; z-index: 1000; background: rgba(0,0,0,0.5); display: none; align-items: center; justify-content: center; }
 #gpt-history-preview.show { display: flex; }
 #gpt-history-preview .modal-content { background: var(--background); color: var(--foreground); border: 1px solid var(--ring); border-radius: 0.5rem; padding: 1rem; max-width: 90%; width: 400px; max-height: 80vh; overflow-y: auto; }
@@ -222,6 +230,7 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
     let suggestions = loadSuggestions() || DEFAULT_SUGGESTIONS.slice();
     let options = loadOptions();
     let history = loadHistory();
+    let historyQuery = '';
 
 
 
@@ -544,6 +553,7 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
     historyModal.innerHTML = `
     <div class="modal-content">
         <h2 class="mb-2 text-lg">Prompt History</h2>
+        <input type="text" id="gpt-history-search" class="w-full mb-2" placeholder="Search...">
         <div id="gpt-history-list"></div>
         <div class="mt-2 text-right"><button id="gpt-history-clear" class="btn btn-secondary btn-small">Clear</button> <button id="gpt-history-close" class="btn btn-secondary btn-small">Close</button></div>
     </div>`;
@@ -912,11 +922,20 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
         modal.classList.add('show');
     }
 
+    function filterHistory(list, query) {
+        const q = (query || '').toLowerCase();
+        return list.reduce((acc, h, i) => {
+            if (!q || h.toLowerCase().includes(q)) acc.push([h, i]);
+            return acc;
+        }, []);
+    }
+
     function renderHistory() {
         const wrap = historyModal.querySelector('#gpt-history-list');
         wrap.innerHTML = '';
         const ul = document.createElement('ul');
-        history.forEach((h, i) => {
+        const items = filterHistory(history, historyQuery);
+        items.forEach(([h, i]) => {
             const li = document.createElement('li');
             const span = document.createElement('span');
             const first = h.split(/\r?\n/)[0];
@@ -955,6 +974,8 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
     }
 
     function openHistory() {
+        const input = historyModal.querySelector('#gpt-history-search');
+        if (input) input.value = historyQuery;
         renderHistory();
         historyModal.classList.add('show');
     }
@@ -980,6 +1001,11 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
     historyModal.querySelector('#gpt-history-close').addEventListener('click', () => historyModal.classList.remove('show'));
     historyModal.addEventListener('click', (e) => { if (e.target === historyModal) historyModal.classList.remove('show'); });
     historyModal.querySelector('#gpt-history-clear').addEventListener('click', () => { history = []; saveHistory(history); renderHistory(); });
+    const historySearchInput = historyModal.querySelector('#gpt-history-search');
+    historySearchInput?.addEventListener('input', () => {
+        historyQuery = historySearchInput.value;
+        renderHistory();
+    });
     modal.querySelector('#gpt-setting-theme').addEventListener('change', (e) => { options.theme = e.target.value; saveOptions(options); applyOptions(); });
     modal.querySelector('#gpt-setting-font').addEventListener('change', (e) => { options.font = e.target.value; saveOptions(options); applyOptions(); });
     modal.querySelector('#gpt-setting-custom-font').addEventListener('input', (e) => { options.customFont = e.target.value; saveOptions(options); applyOptions(); });


### PR DESCRIPTION
## Summary
- add search input to history modal
- filter history list by query
- style history search input
- bump version to 1.0.28

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68753bb363bc832590f8b4360e8b1117