### PR TITLE
Update docs for history modal

### DIFF
--- a/openai-codex.user.js
+++ b/openai-codex.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.0.28
+// @version      1.0.29
 // @description  Adds a prompt suggestion dropdown above the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openai-codex-userscript",
-      "version": "1.0.28",
+      "version": "1.0.29",
       "license": "ISC",
       "devDependencies": {
         "esbuild": "^0.25.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.28",
+  "version": "1.0.29",
   "scripts": {
     "build": "node build.js",
     "test": "npm run build && node test.js"

--- a/readme.md
+++ b/readme.md
@@ -25,11 +25,20 @@ where you can manage your prompt suggestions and toggle various UI options:
 * Toggle the repository sidebar that lists detected repositories.
 * Toggle the version sidebar that displays branches for the selected repository.
 * Enable auto-archiving when a task is merged or closed.
+* Import or export your prompt suggestions as a JSON file.
 
 The chosen settings are stored in `localStorage` so they apply whenever the
 script runs. By default both repository and version sidebars are visible while
 auto-archiving for merged and closed tasks is disabled. These behaviours can be
 toggled from the settings modal.
+
+## Prompt history
+
+Click the book icon in the action bar to open the history modal. It lists your
+previous prompts up to the limit defined by `historyLimit` (50 by default). A
+search box filters entries while buttons let you preview, restore or delete
+individual prompts. Use the **Clear** button to remove all stored history.
+Entries are kept in the `gpt-prompt-history` key of `localStorage`.
 
 ## Theme styling
 

--- a/src/header.js
+++ b/src/header.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.0.28
+// @version      1.0.29
 // @description  Adds a prompt suggestion dropdown above the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest


### PR DESCRIPTION
## Summary
- document prompt history modal
- note import/export buttons for prompt suggestions
- bump version to 1.0.29

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877b6c50944832592504379083b1b23