### PR TITLE
Persist sidebar resize

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -118,7 +118,7 @@
   // src/index.ts
   (function() {
     "use strict";
-    const SCRIPT_VERSION = "1.0.29";
+    const SCRIPT_VERSION = "1.0.30";
     const observers = [];
     let promptInputObserver = null;
     let dropdownObserver = null;
@@ -377,10 +377,17 @@
       const header = el.querySelector("div");
       let dragging = false;
       let startX = 0, startY = 0, startLeft = 0, startTop = 0;
+      let resizing = false;
       function savePos() {
         const rect = el.getBoundingClientRect();
         options[prefix + "X"] = rect.left;
         options[prefix + "Y"] = rect.top;
+        options[prefix + "Width"] = rect.width;
+        options[prefix + "Height"] = rect.height;
+        saveOptions(options);
+      }
+      function saveSize() {
+        const rect = el.getBoundingClientRect();
         options[prefix + "Width"] = rect.width;
         options[prefix + "Height"] = rect.height;
         saveOptions(options);
@@ -413,6 +420,22 @@
         savePos();
       }
       el.addEventListener("mouseup", () => savePos());
+      if (typeof ResizeObserver === "function") {
+        const ro = new ResizeObserver(() => {
+          if (resizing) return;
+          resizing = true;
+          const handler = () => {
+            saveSize();
+            el.removeEventListener("mouseup", handler);
+            el.removeEventListener("mouseleave", handler);
+            resizing = false;
+          };
+          el.addEventListener("mouseup", handler);
+          el.addEventListener("mouseleave", handler);
+        });
+        ro.observe(el);
+        observers.push(ro);
+      }
     }
     function ensureSidebarInBounds(el, prefix) {
       const rect = el.getBoundingClientRect();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "scripts": {
     "build": "node build.js",
     "test": "npm run build && node test.js"

--- a/src/index.ts
+++ b/src/index.ts
@@ -281,11 +281,19 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
         const header = el.querySelector('div');
         let dragging = false;
         let startX = 0, startY = 0, startLeft = 0, startTop = 0;
+        let resizing = false;
 
         function savePos() {
             const rect = el.getBoundingClientRect();
             options[prefix + 'X'] = rect.left;
             options[prefix + 'Y'] = rect.top;
+            options[prefix + 'Width'] = rect.width;
+            options[prefix + 'Height'] = rect.height;
+            saveOptions(options);
+        }
+
+        function saveSize() {
+            const rect = el.getBoundingClientRect();
             options[prefix + 'Width'] = rect.width;
             options[prefix + 'Height'] = rect.height;
             saveOptions(options);
@@ -322,6 +330,23 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
         }
 
         el.addEventListener('mouseup', () => savePos());
+
+        if (typeof ResizeObserver === 'function') {
+            const ro = new ResizeObserver(() => {
+                if (resizing) return;
+                resizing = true;
+                const handler = () => {
+                    saveSize();
+                    el.removeEventListener('mouseup', handler);
+                    el.removeEventListener('mouseleave', handler);
+                    resizing = false;
+                };
+                el.addEventListener('mouseup', handler);
+                el.addEventListener('mouseleave', handler);
+            });
+            ro.observe(el);
+            observers.push(ro);
+        }
     }
 
     function ensureSidebarInBounds(el, prefix) {

--- a/test.js
+++ b/test.js
@@ -107,4 +107,38 @@ async function runTest(html, edits = 0) {
   clearDom.window.document.getElementById('gpt-clear-merged').dispatchEvent(new clearDom.window.Event('click', { bubbles: true }));
   await new Promise(r => clearDom.window.setTimeout(r, 800));
   console.log('Bulk merged clicks:', mergedCount);
+
+  // Resize sidebar test
+  const resizeDom = createDom('');
+  class RO {
+    constructor(cb) { this.cb = cb; RO.instances.push(this); }
+    observe() {}
+    disconnect() {}
+  }
+  RO.instances = [];
+  resizeDom.window.ResizeObserver = RO;
+  resizeDom.window.eval(script);
+  await new Promise(r => resizeDom.window.setTimeout(r, 0));
+  const repoEl = resizeDom.window.document.getElementById('gpt-repo-sidebar');
+  repoEl.style.width = '250px';
+  repoEl.style.height = '260px';
+  repoEl.getBoundingClientRect = () => ({
+    left: 0,
+    top: 0,
+    width: 250,
+    height: 260,
+    right: 250,
+    bottom: 260
+  });
+  RO.instances.forEach(i => i.cb());
+  repoEl.dispatchEvent(new resizeDom.window.Event('mouseup', { bubbles: true }));
+  const saved = JSON.parse(resizeDom.window.localStorage.getItem('gpt-script-options'));
+  console.log('Resize saved:', saved.repoSidebarWidth === 250 && saved.repoSidebarHeight === 260);
+  const reloadDom = createDom('');
+  reloadDom.window.localStorage.setItem('gpt-script-options', JSON.stringify(saved));
+  reloadDom.window.ResizeObserver = RO;
+  reloadDom.window.eval(script);
+  await new Promise(r => reloadDom.window.setTimeout(r, 0));
+  const repoEl2 = reloadDom.window.document.getElementById('gpt-repo-sidebar');
+  console.log('Resize applied:', repoEl2.style.width === '250px' && repoEl2.style.height === '260px');
 })();


### PR DESCRIPTION
## Summary
- persist sidebar width/height when resized
- restore dimensions via `applyOptions`
- test that sidebar resize options save and load
- bump version to 1.0.30

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877c2e9ecd48325b9b7b2b7128a7ad9