### PR TITLE
Filter imported suggestions

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -118,7 +118,7 @@
   // src/index.ts
   (function() {
     "use strict";
-    const SCRIPT_VERSION = "1.0.29";
+    const SCRIPT_VERSION = "1.0.30";
     const observers = [];
     let promptInputObserver = null;
     let dropdownObserver = null;
@@ -940,7 +940,10 @@
             try {
               const data = JSON.parse(String(reader.result));
               if (Array.isArray(data) && data.every((d) => typeof d === "string")) {
-                suggestions = data.map((d) => String(d).trim());
+                const list = Array.from(new Set(
+                  data.map((d) => String(d).trim()).filter(Boolean)
+                ));
+                suggestions = list;
                 saveSuggestions(suggestions);
                 renderSuggestions();
                 refreshDropdown();

--- a/openai-codex.user.js
+++ b/openai-codex.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.0.29
+// @version      1.0.30
 // @description  Adds a prompt suggestion dropdown above the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest
@@ -127,7 +127,7 @@
   // src/index.ts
   (function() {
     "use strict";
-    const SCRIPT_VERSION = "1.0.29";
+    const SCRIPT_VERSION = "1.0.30";
     const observers = [];
     let promptInputObserver = null;
     let dropdownObserver = null;
@@ -949,7 +949,10 @@
             try {
               const data = JSON.parse(String(reader.result));
               if (Array.isArray(data) && data.every((d) => typeof d === "string")) {
-                suggestions = data.map((d) => String(d).trim());
+                const list = Array.from(new Set(
+                  data.map((d) => String(d).trim()).filter(Boolean)
+                ));
+                suggestions = list;
                 saveSuggestions(suggestions);
                 renderSuggestions();
                 refreshDropdown();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.29",
+  "version": "1.0.30",
   "scripts": {
     "build": "node build.js",
     "test": "npm run build && node test.js"

--- a/src/index.ts
+++ b/src/index.ts
@@ -872,7 +872,10 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
                     try {
                         const data = JSON.parse(String(reader.result));
                         if (Array.isArray(data) && data.every(d => typeof d === 'string')) {
-                            suggestions = data.map(d => String(d).trim());
+                            const list = Array.from(new Set(
+                                data.map(d => String(d).trim()).filter(Boolean)
+                            ));
+                            suggestions = list;
                             saveSuggestions(suggestions);
                             renderSuggestions();
                             refreshDropdown();

--- a/test.js
+++ b/test.js
@@ -107,4 +107,32 @@ async function runTest(html, edits = 0) {
   clearDom.window.document.getElementById('gpt-clear-merged').dispatchEvent(new clearDom.window.Event('click', { bubbles: true }));
   await new Promise(r => clearDom.window.setTimeout(r, 800));
   console.log('Bulk merged clicks:', mergedCount);
+
+  // Import suggestions test
+  const importDom = createDom(textareaHtml);
+  const data = ["dup", "", "dup", "unique", " "];
+  const json = JSON.stringify(data);
+  const blob = new importDom.window.Blob([json], { type: 'application/json' });
+  class FakeReader {
+    readAsText() { this.result = json; this.onload(); }
+    onload() {}
+  }
+  importDom.window.FileReader = FakeReader;
+  const origClick = importDom.window.HTMLInputElement.prototype.click;
+  importDom.window.HTMLInputElement.prototype.click = function() {
+    if (this.type === 'file') {
+      Object.defineProperty(this, 'files', { value: [blob], configurable: true });
+      this.dispatchEvent(new importDom.window.Event('change', { bubbles: true }));
+    } else { origClick.call(this); }
+  };
+  importDom.window.eval(script);
+  await new Promise(r => importDom.window.setTimeout(r, 0));
+  importDom.window.document.getElementById('gpt-settings-btn').dispatchEvent(new importDom.window.Event('click', { bubbles: true }));
+  await new Promise(r => importDom.window.setTimeout(r, 0));
+  const importBtn = Array.from(importDom.window.document.querySelectorAll('#gpt-settings-suggestions button')).find(b => b.textContent === 'Import');
+  importBtn.dispatchEvent(new importDom.window.Event('click', { bubbles: true }));
+  await new Promise(r => importDom.window.setTimeout(r, 0));
+  importDom.window.HTMLInputElement.prototype.click = origClick;
+  const stored = JSON.parse(importDom.window.localStorage.getItem('gpt-prompt-suggestions'));
+  console.log('Imported suggestions:', stored);
 })();


### PR DESCRIPTION
## Summary
- filter duplicates and blank lines when importing suggestions
- add unit test for importing repeated/empty suggestions
- bump version to 1.0.30

## Testing
- `npm run build`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877c2f7c1a48325a550929a31da550a