### PR TITLE
Handle duplicate suggestions on import

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -118,7 +118,7 @@
   // src/index.ts
   (function() {
     "use strict";
-    const SCRIPT_VERSION = "1.0.31";
+    const SCRIPT_VERSION = "1.0.32";
     const observers = [];
     let promptInputObserver = null;
     let dropdownObserver = null;
@@ -952,14 +952,20 @@
           reader.onload = () => {
             try {
               const data = JSON.parse(String(reader.result));
-              if (Array.isArray(data) && data.every((d) => typeof d === "string")) {
-                const list = Array.from(new Set(
-                  data.map((d) => String(d).trim()).filter(Boolean)
-                ));
-                suggestions = list;
-                saveSuggestions(suggestions);
-                renderSuggestions();
-                refreshDropdown();
+              if (Array.isArray(data)) {
+                const list = Array.from(
+                  new Set(
+                    data.map((d) => String(d).trim()).filter((s) => s.length > 0)
+                  )
+                );
+                if (list.length > 0) {
+                  suggestions = list;
+                  saveSuggestions(suggestions);
+                  renderSuggestions();
+                  refreshDropdown();
+                } else {
+                  window.alert("Invalid suggestions file");
+                }
               } else {
                 window.alert("Invalid suggestions file");
               }

--- a/openai-codex.user.js
+++ b/openai-codex.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.0.31
+// @version      1.0.32
 // @description  Adds a prompt suggestion dropdown above the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest
@@ -127,7 +127,7 @@
   // src/index.ts
   (function() {
     "use strict";
-    const SCRIPT_VERSION = "1.0.31";
+    const SCRIPT_VERSION = "1.0.32";
     const observers = [];
     let promptInputObserver = null;
     let dropdownObserver = null;
@@ -961,14 +961,20 @@
           reader.onload = () => {
             try {
               const data = JSON.parse(String(reader.result));
-              if (Array.isArray(data) && data.every((d) => typeof d === "string")) {
-                const list = Array.from(new Set(
-                  data.map((d) => String(d).trim()).filter(Boolean)
-                ));
-                suggestions = list;
-                saveSuggestions(suggestions);
-                renderSuggestions();
-                refreshDropdown();
+              if (Array.isArray(data)) {
+                const list = Array.from(
+                  new Set(
+                    data.map((d) => String(d).trim()).filter((s) => s.length > 0)
+                  )
+                );
+                if (list.length > 0) {
+                  suggestions = list;
+                  saveSuggestions(suggestions);
+                  renderSuggestions();
+                  refreshDropdown();
+                } else {
+                  window.alert("Invalid suggestions file");
+                }
               } else {
                 window.alert("Invalid suggestions file");
               }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.29",
+  "version": "1.0.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openai-codex-userscript",
-      "version": "1.0.29",
+      "version": "1.0.31",
       "license": "ISC",
       "devDependencies": {
         "esbuild": "^0.25.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.31",
+  "version": "1.0.32",
   "scripts": {
     "build": "node build.js",
     "test": "npm run build && node test.js"

--- a/src/header.js
+++ b/src/header.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.0.31
+// @version      1.0.32
 // @description  Adds a prompt suggestion dropdown above the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest

--- a/src/index.ts
+++ b/src/index.ts
@@ -885,14 +885,22 @@ import { findPromptInput, setPromptText } from "./helpers/dom";
                 reader.onload = () => {
                     try {
                         const data = JSON.parse(String(reader.result));
-                        if (Array.isArray(data) && data.every(d => typeof d === 'string')) {
-                            const list = Array.from(new Set(
-                                data.map(d => String(d).trim()).filter(Boolean)
-                            ));
-                            suggestions = list;
-                            saveSuggestions(suggestions);
-                            renderSuggestions();
-                            refreshDropdown();
+                        if (Array.isArray(data)) {
+                            const list = Array.from(
+                                new Set(
+                                    data
+                                        .map(d => String(d).trim())
+                                        .filter(s => s.length > 0)
+                                )
+                            );
+                            if (list.length > 0) {
+                                suggestions = list;
+                                saveSuggestions(suggestions);
+                                renderSuggestions();
+                                refreshDropdown();
+                            } else {
+                                window.alert('Invalid suggestions file');
+                            }
                         } else {
                             window.alert('Invalid suggestions file');
                         }

--- a/test.js
+++ b/test.js
@@ -189,11 +189,13 @@ function parseRepoNames(list) {
   }
   importDom.window.FileReader = FakeReader;
   const origClick = importDom.window.HTMLInputElement.prototype.click;
-  importDom.window.HTMLInputElement.prototype.click = function() {
+  importDom.window.HTMLInputElement.prototype.click = function () {
     if (this.type === 'file') {
       Object.defineProperty(this, 'files', { value: [blob], configurable: true });
       this.dispatchEvent(new importDom.window.Event('change', { bubbles: true }));
-    } else { origClick.call(this); }
+    } else {
+      origClick.call(this);
+    }
   };
   importDom.window.eval(script);
   await new Promise(r => importDom.window.setTimeout(r, 0));
@@ -204,7 +206,7 @@ function parseRepoNames(list) {
   await new Promise(r => importDom.window.setTimeout(r, 0));
   importDom.window.HTMLInputElement.prototype.click = origClick;
   const stored = JSON.parse(importDom.window.localStorage.getItem('gpt-prompt-suggestions'));
-  console.log('Imported suggestions:', stored);
+  assert.deepStrictEqual(stored, ['dup', 'unique']);
 
   // Sidebar resize test
   const resizeDom = createDom('');


### PR DESCRIPTION
## Summary
- filter blank strings and remove duplicates when importing suggestions
- update the import suggestions unit test
- bump version to 1.0.32

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877cc791ffc8325b1313fd627f37cbf