### PR TITLE
Add three column layout option

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -73,6 +73,7 @@
         hideLogoImage: false,
         hideProfile: false,
         hideEnvironments: false,
+        threeColumnMode: false,
         autoCheckUpdates: false,
         showRepoSidebar: true,
         showVersionSidebar: true,
@@ -149,7 +150,7 @@
   var VERSION;
   var init_version = __esm({
     "src/version.ts"() {
-      VERSION = "1.0.33";
+      VERSION = "1.0.35";
     }
   });
 
@@ -378,6 +379,49 @@
 }
 `;
         document.head.appendChild(fallbackStyle);
+        const columnStyle = document.createElement("style");
+        columnStyle.id = "gpt-three-column-style";
+        columnStyle.textContent = `
+div.h-full > div > div.justify-center:nth-child(2) {
+  display: block !important;
+  width: 100vw !important;
+  max-width: none !important;
+  margin: 0 !important;
+  padding: 2rem 3vw !important;
+  box-sizing: border-box !important;
+
+  column-count: 3;
+  column-gap: 2.5rem;
+  height: auto !important;
+}
+
+div.justify-center:nth-child(2) > * {
+  width: auto !important;
+  display: block !important;
+  left: 0 !important;
+  max-width: 100% !important;
+  box-sizing: border-box !important;
+}
+
+div.mx-auto {
+    width: 100vw;
+}
+
+div.h-full > div > div.z-50 {
+    width: 33vw;
+    align-items: center !important;
+    margin: auto;
+}
+
+div.justify-center:nth-child(2) {
+  max-width: none !important;
+  margin: 0 !important;
+}
+
+body, html {
+  overflow: visible !important;
+  width: 100vw !important;
+}`;
         let suggestions = loadSuggestions() || DEFAULT_SUGGESTIONS.slice();
         let options = loadOptions();
         let history = loadHistory();
@@ -551,6 +595,11 @@
           toggleEnvironments(options.hideEnvironments);
           toggleRepoSidebar(options.showRepoSidebar);
           toggleVersionSidebar(options.showVersionSidebar);
+          if (options.threeColumnMode) {
+            if (!document.head.contains(columnStyle)) document.head.appendChild(columnStyle);
+          } else {
+            if (columnStyle.parentNode) columnStyle.parentNode.removeChild(columnStyle);
+          }
           const repoEl = document.getElementById("gpt-repo-sidebar");
           if (repoEl) {
             if (options.repoSidebarX !== null) repoEl.style.left = options.repoSidebarX + "px";
@@ -666,7 +715,8 @@
             <label><input type="checkbox" id="gpt-setting-logo-text"> Hide logo text</label><br>
             <label><input type="checkbox" id="gpt-setting-logo-image"> Hide logo image</label><br>
             <label><input type="checkbox" id="gpt-setting-profile"> Hide profile icon</label><br>
-            <label><input type="checkbox" id="gpt-setting-environments"> Hide environments button</label>
+            <label><input type="checkbox" id="gpt-setting-environments"> Hide environments button</label><br>
+            <label><input type="checkbox" id="gpt-setting-three-column"> 3 column layout</label>
         </div>
         <div class="settings-group">
             <h3>Sidebars</h3>
@@ -1042,6 +1092,7 @@
           modal.querySelector("#gpt-setting-logo-image").checked = options.hideLogoImage;
           modal.querySelector("#gpt-setting-profile").checked = options.hideProfile;
           modal.querySelector("#gpt-setting-environments").checked = options.hideEnvironments;
+          modal.querySelector("#gpt-setting-three-column").checked = options.threeColumnMode;
           modal.querySelector("#gpt-setting-auto-updates").checked = options.autoCheckUpdates;
           modal.querySelector("#gpt-setting-disable-history").checked = options.disableHistory;
           modal.querySelector("#gpt-setting-history-limit").value = String(options.historyLimit);
@@ -1181,6 +1232,11 @@
         });
         modal.querySelector("#gpt-setting-environments").addEventListener("change", (e) => {
           options.hideEnvironments = e.target.checked;
+          saveOptions(options);
+          applyOptions();
+        });
+        modal.querySelector("#gpt-setting-three-column").addEventListener("change", (e) => {
+          options.threeColumnMode = e.target.checked;
           saveOptions(options);
           applyOptions();
         });

--- a/openai-codex.user.js
+++ b/openai-codex.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.0.33
+// @version      1.0.35
 // @description  Adds a prompt suggestion dropdown above the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest
@@ -82,6 +82,7 @@
         hideLogoImage: false,
         hideProfile: false,
         hideEnvironments: false,
+        threeColumnMode: false,
         autoCheckUpdates: false,
         showRepoSidebar: true,
         showVersionSidebar: true,
@@ -158,7 +159,7 @@
   var VERSION;
   var init_version = __esm({
     "src/version.ts"() {
-      VERSION = "1.0.33";
+      VERSION = "1.0.35";
     }
   });
 
@@ -387,6 +388,49 @@
 }
 `;
         document.head.appendChild(fallbackStyle);
+        const columnStyle = document.createElement("style");
+        columnStyle.id = "gpt-three-column-style";
+        columnStyle.textContent = `
+div.h-full > div > div.justify-center:nth-child(2) {
+  display: block !important;
+  width: 100vw !important;
+  max-width: none !important;
+  margin: 0 !important;
+  padding: 2rem 3vw !important;
+  box-sizing: border-box !important;
+
+  column-count: 3;
+  column-gap: 2.5rem;
+  height: auto !important;
+}
+
+div.justify-center:nth-child(2) > * {
+  width: auto !important;
+  display: block !important;
+  left: 0 !important;
+  max-width: 100% !important;
+  box-sizing: border-box !important;
+}
+
+div.mx-auto {
+    width: 100vw;
+}
+
+div.h-full > div > div.z-50 {
+    width: 33vw;
+    align-items: center !important;
+    margin: auto;
+}
+
+div.justify-center:nth-child(2) {
+  max-width: none !important;
+  margin: 0 !important;
+}
+
+body, html {
+  overflow: visible !important;
+  width: 100vw !important;
+}`;
         let suggestions = loadSuggestions() || DEFAULT_SUGGESTIONS.slice();
         let options = loadOptions();
         let history = loadHistory();
@@ -560,6 +604,11 @@
           toggleEnvironments(options.hideEnvironments);
           toggleRepoSidebar(options.showRepoSidebar);
           toggleVersionSidebar(options.showVersionSidebar);
+          if (options.threeColumnMode) {
+            if (!document.head.contains(columnStyle)) document.head.appendChild(columnStyle);
+          } else {
+            if (columnStyle.parentNode) columnStyle.parentNode.removeChild(columnStyle);
+          }
           const repoEl = document.getElementById("gpt-repo-sidebar");
           if (repoEl) {
             if (options.repoSidebarX !== null) repoEl.style.left = options.repoSidebarX + "px";
@@ -675,7 +724,8 @@
             <label><input type="checkbox" id="gpt-setting-logo-text"> Hide logo text</label><br>
             <label><input type="checkbox" id="gpt-setting-logo-image"> Hide logo image</label><br>
             <label><input type="checkbox" id="gpt-setting-profile"> Hide profile icon</label><br>
-            <label><input type="checkbox" id="gpt-setting-environments"> Hide environments button</label>
+            <label><input type="checkbox" id="gpt-setting-environments"> Hide environments button</label><br>
+            <label><input type="checkbox" id="gpt-setting-three-column"> 3 column layout</label>
         </div>
         <div class="settings-group">
             <h3>Sidebars</h3>
@@ -1051,6 +1101,7 @@
           modal.querySelector("#gpt-setting-logo-image").checked = options.hideLogoImage;
           modal.querySelector("#gpt-setting-profile").checked = options.hideProfile;
           modal.querySelector("#gpt-setting-environments").checked = options.hideEnvironments;
+          modal.querySelector("#gpt-setting-three-column").checked = options.threeColumnMode;
           modal.querySelector("#gpt-setting-auto-updates").checked = options.autoCheckUpdates;
           modal.querySelector("#gpt-setting-disable-history").checked = options.disableHistory;
           modal.querySelector("#gpt-setting-history-limit").value = String(options.historyLimit);
@@ -1190,6 +1241,11 @@
         });
         modal.querySelector("#gpt-setting-environments").addEventListener("change", (e) => {
           options.hideEnvironments = e.target.checked;
+          saveOptions(options);
+          applyOptions();
+        });
+        modal.querySelector("#gpt-setting-three-column").addEventListener("change", (e) => {
+          options.threeColumnMode = e.target.checked;
           saveOptions(options);
           applyOptions();
         });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.33",
+  "version": "1.0.35",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openai-codex-userscript",
-      "version": "1.0.33",
+      "version": "1.0.35",
       "license": "ISC",
       "devDependencies": {
         "esbuild": "^0.25.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.33",
+  "version": "1.0.35",
   "scripts": {
     "build": "node build.js",
     "test": "npm run build && node test.js"

--- a/src/helpers/options.ts
+++ b/src/helpers/options.ts
@@ -10,6 +10,7 @@ export interface Options {
   hideLogoImage: boolean;
   hideProfile: boolean;
   hideEnvironments: boolean;
+  threeColumnMode: boolean;
   autoCheckUpdates: boolean;
   showRepoSidebar: boolean;
   showVersionSidebar: boolean;
@@ -40,6 +41,7 @@ export const DEFAULT_OPTIONS: Options = {
   hideLogoImage: false,
   hideProfile: false,
   hideEnvironments: false,
+  threeColumnMode: false,
   autoCheckUpdates: false,
   showRepoSidebar: true,
   showVersionSidebar: true,

--- a/src/index.ts
+++ b/src/index.ts
@@ -228,6 +228,50 @@ import { VERSION } from "./version";
 }
 `;
     document.head.appendChild(fallbackStyle);
+
+    const columnStyle = document.createElement('style');
+    columnStyle.id = 'gpt-three-column-style';
+    columnStyle.textContent = `
+div.h-full > div > div.justify-center:nth-child(2) {
+  display: block !important;
+  width: 100vw !important;
+  max-width: none !important;
+  margin: 0 !important;
+  padding: 2rem 3vw !important;
+  box-sizing: border-box !important;
+
+  column-count: 3;
+  column-gap: 2.5rem;
+  height: auto !important;
+}
+
+div.justify-center:nth-child(2) > * {
+  width: auto !important;
+  display: block !important;
+  left: 0 !important;
+  max-width: 100% !important;
+  box-sizing: border-box !important;
+}
+
+div.mx-auto {
+    width: 100vw;
+}
+
+div.h-full > div > div.z-50 {
+    width: 33vw;
+    align-items: center !important;
+    margin: auto;
+}
+
+div.justify-center:nth-child(2) {
+  max-width: none !important;
+  margin: 0 !important;
+}
+
+body, html {
+  overflow: visible !important;
+  width: 100vw !important;
+}`;
     let suggestions = loadSuggestions() || DEFAULT_SUGGESTIONS.slice();
     let options = loadOptions();
     let history = loadHistory();
@@ -413,6 +457,12 @@ import { VERSION } from "./version";
         toggleRepoSidebar(options.showRepoSidebar);
         toggleVersionSidebar(options.showVersionSidebar);
 
+        if (options.threeColumnMode) {
+            if (!document.head.contains(columnStyle)) document.head.appendChild(columnStyle);
+        } else {
+            if (columnStyle.parentNode) columnStyle.parentNode.removeChild(columnStyle);
+        }
+
         const repoEl = document.getElementById('gpt-repo-sidebar');
         if (repoEl) {
             if (options.repoSidebarX !== null) repoEl.style.left = options.repoSidebarX + 'px';
@@ -535,7 +585,8 @@ import { VERSION } from "./version";
             <label><input type="checkbox" id="gpt-setting-logo-text"> Hide logo text</label><br>
             <label><input type="checkbox" id="gpt-setting-logo-image"> Hide logo image</label><br>
             <label><input type="checkbox" id="gpt-setting-profile"> Hide profile icon</label><br>
-            <label><input type="checkbox" id="gpt-setting-environments"> Hide environments button</label>
+            <label><input type="checkbox" id="gpt-setting-environments"> Hide environments button</label><br>
+            <label><input type="checkbox" id="gpt-setting-three-column"> 3 column layout</label>
         </div>
         <div class="settings-group">
             <h3>Sidebars</h3>
@@ -935,6 +986,7 @@ import { VERSION } from "./version";
         modal.querySelector('#gpt-setting-logo-image').checked = options.hideLogoImage;
         modal.querySelector('#gpt-setting-profile').checked = options.hideProfile;
         modal.querySelector('#gpt-setting-environments').checked = options.hideEnvironments;
+        modal.querySelector('#gpt-setting-three-column').checked = options.threeColumnMode;
         modal.querySelector('#gpt-setting-auto-updates').checked = options.autoCheckUpdates;
         modal.querySelector('#gpt-setting-disable-history').checked = options.disableHistory;
         modal.querySelector('#gpt-setting-history-limit').value = String(options.historyLimit);
@@ -1041,6 +1093,7 @@ import { VERSION } from "./version";
     modal.querySelector('#gpt-setting-logo-image').addEventListener('change', (e) => { options.hideLogoImage = e.target.checked; saveOptions(options); applyOptions(); });
     modal.querySelector('#gpt-setting-profile').addEventListener('change', (e) => { options.hideProfile = e.target.checked; saveOptions(options); applyOptions(); });
     modal.querySelector('#gpt-setting-environments').addEventListener('change', (e) => { options.hideEnvironments = e.target.checked; saveOptions(options); applyOptions(); });
+    modal.querySelector('#gpt-setting-three-column').addEventListener('change', (e) => { options.threeColumnMode = e.target.checked; saveOptions(options); applyOptions(); });
     modal.querySelector('#gpt-setting-auto-updates').addEventListener('change', (e) => { options.autoCheckUpdates = e.target.checked; saveOptions(options); });
     modal.querySelector('#gpt-setting-disable-history').addEventListener('change', (e) => { options.disableHistory = e.target.checked; saveOptions(options); });
     modal.querySelector('#gpt-setting-history-limit').addEventListener('change', (e) => { options.historyLimit = parseInt(e.target.value, 10) || 1; saveOptions(options); });


### PR DESCRIPTION
## Summary
- allow enabling a 3 column layout from settings
- generate style injection for new layout
- bump version to 1.0.35
- tweak layout selector so overlay width only applies to main container

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687a2a15e7208325b50ce190b0812502