### PR TITLE
feat: add auto-healing header selector

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -197,7 +197,7 @@
   var VERSION;
   var init_version = __esm({
     "src/version.ts"() {
-      VERSION = "1.0.36";
+      VERSION = "1.0.37";
     }
   });
 
@@ -479,9 +479,18 @@ body, html {
           return elements.find((el) => el.textContent && el.textContent.includes(text)) || null;
         }
         function toggleHeader(hide) {
-          var _a;
-          const node = document.querySelector("h1.mb-4.pt-4.text-2xl");
-          if (node && ((_a = node.textContent) == null ? void 0 : _a.includes("What are we coding next?"))) {
+          const targetTexts = ["What are we coding next?", "What should we code next?"];
+          let node = document.querySelector("h1.mb-4.pt-4.text-2xl");
+          if (!node || !targetTexts.some((t) => {
+            var _a;
+            return (_a = node.textContent) == null ? void 0 : _a.includes(t);
+          })) {
+            node = findByText("What should we code next?");
+          }
+          if (node && targetTexts.some((t) => {
+            var _a;
+            return (_a = node.textContent) == null ? void 0 : _a.includes(t);
+          })) {
             node.style.display = hide ? "none" : "";
           }
         }

--- a/openai-codex.user.js
+++ b/openai-codex.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.0.36
+// @version      1.0.37
 // @description  Adds a prompt suggestion dropdown above the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest
@@ -206,7 +206,7 @@
   var VERSION;
   var init_version = __esm({
     "src/version.ts"() {
-      VERSION = "1.0.36";
+      VERSION = "1.0.37";
     }
   });
 
@@ -488,9 +488,18 @@ body, html {
           return elements.find((el) => el.textContent && el.textContent.includes(text)) || null;
         }
         function toggleHeader(hide) {
-          var _a;
-          const node = document.querySelector("h1.mb-4.pt-4.text-2xl");
-          if (node && ((_a = node.textContent) == null ? void 0 : _a.includes("What are we coding next?"))) {
+          const targetTexts = ["What are we coding next?", "What should we code next?"];
+          let node = document.querySelector("h1.mb-4.pt-4.text-2xl");
+          if (!node || !targetTexts.some((t) => {
+            var _a;
+            return (_a = node.textContent) == null ? void 0 : _a.includes(t);
+          })) {
+            node = findByText("What should we code next?");
+          }
+          if (node && targetTexts.some((t) => {
+            var _a;
+            return (_a = node.textContent) == null ? void 0 : _a.includes(t);
+          })) {
             node.style.display = hide ? "none" : "";
           }
         }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.36",
+  "version": "1.0.37",
   "scripts": {
     "build": "node build.js",
     "test": "npm run build && node --test -r ts-node/register \"tests/**/*.test.ts\""

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ A floating gear icon is added to the side of the page. Clicking it opens a modal
 where you can manage your prompt suggestions and toggle various UI options:
 
 * Switch between Light, Dark and OLED themes.
-* Hide the “What are we coding next?” header.
+* Hide the “What should we code next?” header.
 * Hide the “Docs” navigation link.
 * Hide the "Environments" button.
 * Toggle the repository sidebar that lists detected repositories.

--- a/src/header.js
+++ b/src/header.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.0.36
+// @version      1.0.37
 // @description  Adds a prompt suggestion dropdown above the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest

--- a/src/index.ts
+++ b/src/index.ts
@@ -287,8 +287,12 @@ body, html {
     }
 
     function toggleHeader(hide) {
-        const node = document.querySelector('h1.mb-4.pt-4.text-2xl');
-        if (node && node.textContent?.includes('What are we coding next?')) {
+        const targetTexts = ['What are we coding next?', 'What should we code next?'];
+        let node = document.querySelector('h1.mb-4.pt-4.text-2xl');
+        if (!node || !targetTexts.some(t => node.textContent?.includes(t))) {
+            node = findByText('What should we code next?');
+        }
+        if (node && targetTexts.some(t => node.textContent?.includes(t))) {
             node.style.display = hide ? 'none' : '';
         }
     }


### PR DESCRIPTION
## Summary
- make header selection resilient by falling back to text search for "What should we code next?"
- document new header wording and bump version to 1.0.37

## Testing
- `npm run build`
- `npm test` *(fails: Could not find '/workspace/openai-codex-userscript/tests/**/*.test.ts')*
- `node --test -r ts-node/register tests/history.test.ts tests/sidebar.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68a4bf70527883259ef0ab009769fdf3