### PR TITLE
Add localStorage fallback for disabled environments

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -24,9 +24,33 @@
   };
 
   // src/lib/storage.ts
+  function getItem(key) {
+    var _a;
+    if (hasLocalStorage) {
+      try {
+        return localStorage.getItem(key);
+      } catch (e) {
+        console.error("localStorage unavailable, using in-memory storage", e);
+        hasLocalStorage = false;
+      }
+    }
+    return (_a = memoryStorage.get(key)) != null ? _a : null;
+  }
+  function setItem(key, value) {
+    if (hasLocalStorage) {
+      try {
+        localStorage.setItem(key, value);
+        return;
+      } catch (e) {
+        console.error("localStorage unavailable, using in-memory storage", e);
+        hasLocalStorage = false;
+      }
+    }
+    memoryStorage.set(key, value);
+  }
   function loadJSON(key, fallback) {
     try {
-      const raw = localStorage.getItem(key);
+      const raw = getItem(key);
       if (raw) {
         return JSON.parse(raw);
       }
@@ -37,13 +61,16 @@
   }
   function saveJSON(key, data) {
     try {
-      localStorage.setItem(key, JSON.stringify(data));
+      setItem(key, JSON.stringify(data));
     } catch (e) {
       console.error(`Failed to save ${key}`, e);
     }
   }
+  var memoryStorage, hasLocalStorage;
   var init_storage = __esm({
     "src/lib/storage.ts"() {
+      memoryStorage = /* @__PURE__ */ new Map();
+      hasLocalStorage = true;
     }
   });
 
@@ -197,7 +224,7 @@
   var VERSION;
   var init_version = __esm({
     "src/version.ts"() {
-      VERSION = "1.0.37";
+      VERSION = "1.0.38";
     }
   });
 

--- a/dist/lib/storage.js
+++ b/dist/lib/storage.js
@@ -2,23 +2,51 @@
 Object.defineProperty(exports, "__esModule", { value: true });
 exports.loadJSON = loadJSON;
 exports.saveJSON = saveJSON;
+var memoryStorage = new Map();
+var hasLocalStorage = true;
+function getItem(key) {
+    var _a;
+    if (hasLocalStorage) {
+        try {
+            return localStorage.getItem(key);
+        }
+        catch (e) {
+            console.error('localStorage unavailable, using in-memory storage', e);
+            hasLocalStorage = false;
+        }
+    }
+    return (_a = memoryStorage.get(key)) !== null && _a !== void 0 ? _a : null;
+}
+function setItem(key, value) {
+    if (hasLocalStorage) {
+        try {
+            localStorage.setItem(key, value);
+            return;
+        }
+        catch (e) {
+            console.error('localStorage unavailable, using in-memory storage', e);
+            hasLocalStorage = false;
+        }
+    }
+    memoryStorage.set(key, value);
+}
 function loadJSON(key, fallback) {
     try {
-        const raw = localStorage.getItem(key);
+        var raw = getItem(key);
         if (raw) {
             return JSON.parse(raw);
         }
     }
     catch (e) {
-        console.error(`Failed to load ${key}`, e);
+        console.error("Failed to load ".concat(key), e);
     }
     return fallback;
 }
 function saveJSON(key, data) {
     try {
-        localStorage.setItem(key, JSON.stringify(data));
+        setItem(key, JSON.stringify(data));
     }
     catch (e) {
-        console.error(`Failed to save ${key}`, e);
+        console.error("Failed to save ".concat(key), e);
     }
 }

--- a/openai-codex.user.js
+++ b/openai-codex.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.0.37
+// @version      1.0.38
 // @description  Adds a prompt suggestion dropdown above the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest
@@ -33,9 +33,33 @@
   };
 
   // src/lib/storage.ts
+  function getItem(key) {
+    var _a;
+    if (hasLocalStorage) {
+      try {
+        return localStorage.getItem(key);
+      } catch (e) {
+        console.error("localStorage unavailable, using in-memory storage", e);
+        hasLocalStorage = false;
+      }
+    }
+    return (_a = memoryStorage.get(key)) != null ? _a : null;
+  }
+  function setItem(key, value) {
+    if (hasLocalStorage) {
+      try {
+        localStorage.setItem(key, value);
+        return;
+      } catch (e) {
+        console.error("localStorage unavailable, using in-memory storage", e);
+        hasLocalStorage = false;
+      }
+    }
+    memoryStorage.set(key, value);
+  }
   function loadJSON(key, fallback) {
     try {
-      const raw = localStorage.getItem(key);
+      const raw = getItem(key);
       if (raw) {
         return JSON.parse(raw);
       }
@@ -46,13 +70,16 @@
   }
   function saveJSON(key, data) {
     try {
-      localStorage.setItem(key, JSON.stringify(data));
+      setItem(key, JSON.stringify(data));
     } catch (e) {
       console.error(`Failed to save ${key}`, e);
     }
   }
+  var memoryStorage, hasLocalStorage;
   var init_storage = __esm({
     "src/lib/storage.ts"() {
+      memoryStorage = /* @__PURE__ */ new Map();
+      hasLocalStorage = true;
     }
   });
 
@@ -206,7 +233,7 @@
   var VERSION;
   var init_version = __esm({
     "src/version.ts"() {
-      VERSION = "1.0.37";
+      VERSION = "1.0.38";
     }
   });
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.36",
+  "version": "1.0.38",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openai-codex-userscript",
-      "version": "1.0.36",
+      "version": "1.0.38",
       "license": "ISC",
       "devDependencies": {
         "esbuild": "^0.25.6",

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.37",
+  "version": "1.0.38",
   "scripts": {
     "build": "node build.js",
-    "test": "npm run build && node --test -r ts-node/register \"tests/**/*.test.ts\""
+    "test": "npm run build && node --test -r ts-node/register tests/*.test.ts"
   },
   "devDependencies": {
     "esbuild": "^0.25.6",

--- a/src/header.js
+++ b/src/header.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.0.37
+// @version      1.0.38
 // @description  Adds a prompt suggestion dropdown above the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -1,6 +1,35 @@
+const memoryStorage = new Map<string, string>();
+
+let hasLocalStorage = true;
+
+function getItem(key: string): string | null {
+  if (hasLocalStorage) {
+    try {
+      return localStorage.getItem(key);
+    } catch (e) {
+      console.error('localStorage unavailable, using in-memory storage', e);
+      hasLocalStorage = false;
+    }
+  }
+  return memoryStorage.get(key) ?? null;
+}
+
+function setItem(key: string, value: string): void {
+  if (hasLocalStorage) {
+    try {
+      localStorage.setItem(key, value);
+      return;
+    } catch (e) {
+      console.error('localStorage unavailable, using in-memory storage', e);
+      hasLocalStorage = false;
+    }
+  }
+  memoryStorage.set(key, value);
+}
+
 export function loadJSON<T>(key: string, fallback: T): T {
   try {
-    const raw = localStorage.getItem(key);
+    const raw = getItem(key);
     if (raw) {
       return JSON.parse(raw) as T;
     }
@@ -12,7 +41,7 @@ export function loadJSON<T>(key: string, fallback: T): T {
 
 export function saveJSON(key: string, data: any): void {
   try {
-    localStorage.setItem(key, JSON.stringify(data));
+    setItem(key, JSON.stringify(data));
   } catch (e) {
     console.error(`Failed to save ${key}`, e);
   }

--- a/tests/storage.test.ts
+++ b/tests/storage.test.ts
@@ -1,0 +1,26 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { loadJSON, saveJSON } from '../src/lib/storage';
+
+test('falls back to memory storage when localStorage disabled', { concurrency: false }, () => {
+  const error = new Error('denied');
+  (globalThis as any).localStorage = {
+    getItem() { throw error; },
+    setItem() { throw error; }
+  };
+
+  saveJSON('test-key', { a: 1 });
+  const result = loadJSON('test-key', { a: 0 });
+  assert.deepStrictEqual(result, { a: 1 });
+});
+
+test('loadJSON returns fallback with disabled localStorage', { concurrency: false }, () => {
+  const error = new Error('denied');
+  (globalThis as any).localStorage = {
+    getItem() { throw error; },
+    setItem() { throw error; }
+  };
+
+  const result = loadJSON('missing', { b: 2 });
+  assert.deepStrictEqual(result, { b: 2 });
+});


### PR DESCRIPTION
## Summary
- handle localStorage failures by falling back to an in-memory map
- ensure loadJSON/saveJSON use fallback storage
- add tests covering scenarios with disabled localStorage
- bump version to 1.0.38

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6148ec42c8325a8229395e6ac39ed