### PR TITLE
Validate options schema and add tests

### DIFF
--- a/dist/helpers/options.js
+++ b/dist/helpers/options.js
@@ -6,20 +6,81 @@ exports.saveOptions = saveOptions;
 const storage_1 = require("../lib/storage");
 exports.DEFAULT_OPTIONS = {
     theme: null,
+    font: 'sans-serif',
+    customFont: '',
     hideHeader: false,
     hideDocs: false,
     hideLogoText: false,
     hideLogoImage: false,
     hideProfile: false,
-    autoCheckUpdates: true,
+    hideEnvironments: false,
+    threeColumnMode: false,
+    autoCheckUpdates: false,
+    showRepoSidebar: true,
+    showVersionSidebar: true,
+    clearClosedBranches: false,
+    clearMergedBranches: false,
+    clearOpenBranches: false,
+    autoArchiveMerged: false,
+    autoArchiveClosed: false,
+    historyLimit: 50,
+    disableHistory: false,
+    repoSidebarX: null,
+    repoSidebarY: null,
+    repoSidebarWidth: null,
+    repoSidebarHeight: null,
+    versionSidebarX: null,
+    versionSidebarY: null,
+    versionSidebarWidth: null,
+    versionSidebarHeight: null,
 };
 const STORAGE_KEY = 'gpt-script-options';
-function loadOptions() {
-    const opts = (0, storage_1.loadJSON)(STORAGE_KEY, exports.DEFAULT_OPTIONS);
-    const anyOpts = opts;
-    if ('dark' in anyOpts && !('theme' in anyOpts)) {
-        anyOpts.theme = anyOpts.dark ? 'dark' : 'light';
+const OPTION_VALIDATORS = {
+    theme: (v) => v === null || typeof v === 'string',
+    font: (v) => v === 'serif' || v === 'sans-serif' || v === 'monospace' || v === 'custom',
+    customFont: (v) => typeof v === 'string',
+    hideHeader: (v) => typeof v === 'boolean',
+    hideDocs: (v) => typeof v === 'boolean',
+    hideLogoText: (v) => typeof v === 'boolean',
+    hideLogoImage: (v) => typeof v === 'boolean',
+    hideProfile: (v) => typeof v === 'boolean',
+    hideEnvironments: (v) => typeof v === 'boolean',
+    threeColumnMode: (v) => typeof v === 'boolean',
+    autoCheckUpdates: (v) => typeof v === 'boolean',
+    showRepoSidebar: (v) => typeof v === 'boolean',
+    showVersionSidebar: (v) => typeof v === 'boolean',
+    clearClosedBranches: (v) => typeof v === 'boolean',
+    clearMergedBranches: (v) => typeof v === 'boolean',
+    clearOpenBranches: (v) => typeof v === 'boolean',
+    autoArchiveMerged: (v) => typeof v === 'boolean',
+    autoArchiveClosed: (v) => typeof v === 'boolean',
+    historyLimit: (v) => typeof v === 'number' && Number.isFinite(v),
+    disableHistory: (v) => typeof v === 'boolean',
+    repoSidebarX: (v) => (typeof v === 'number' && Number.isFinite(v)) || v === null,
+    repoSidebarY: (v) => (typeof v === 'number' && Number.isFinite(v)) || v === null,
+    repoSidebarWidth: (v) => (typeof v === 'number' && Number.isFinite(v)) || v === null,
+    repoSidebarHeight: (v) => (typeof v === 'number' && Number.isFinite(v)) || v === null,
+    versionSidebarX: (v) => (typeof v === 'number' && Number.isFinite(v)) || v === null,
+    versionSidebarY: (v) => (typeof v === 'number' && Number.isFinite(v)) || v === null,
+    versionSidebarWidth: (v) => (typeof v === 'number' && Number.isFinite(v)) || v === null,
+    versionSidebarHeight: (v) => (typeof v === 'number' && Number.isFinite(v)) || v === null,
+};
+function sanitizeOptions(raw) {
+    const result = {};
+    for (const key in OPTION_VALIDATORS) {
+        const value = raw[key];
+        if (OPTION_VALIDATORS[key](value)) {
+            result[key] = value;
+        }
     }
+    return result;
+}
+function loadOptions() {
+    const raw = (0, storage_1.loadJSON)(STORAGE_KEY, {});
+    if ('dark' in raw && !('theme' in raw)) {
+        raw.theme = raw.dark ? 'dark' : 'light';
+    }
+    const opts = sanitizeOptions(raw);
     return Object.assign(Object.assign({}, exports.DEFAULT_OPTIONS), opts);
 }
 function saveOptions(opts) {

--- a/dist/index.js
+++ b/dist/index.js
@@ -75,18 +75,28 @@
   });
 
   // src/helpers/options.ts
-  function loadOptions() {
-    const opts = loadJSON(STORAGE_KEY, DEFAULT_OPTIONS);
-    const anyOpts = opts;
-    if ("dark" in anyOpts && !("theme" in anyOpts)) {
-      anyOpts.theme = anyOpts.dark ? "dark" : "light";
+  function sanitizeOptions(raw) {
+    const result = {};
+    for (const key in OPTION_VALIDATORS) {
+      const value = raw[key];
+      if (OPTION_VALIDATORS[key](value)) {
+        result[key] = value;
+      }
     }
+    return result;
+  }
+  function loadOptions() {
+    const raw = loadJSON(STORAGE_KEY, {});
+    if ("dark" in raw && !("theme" in raw)) {
+      raw.theme = raw.dark ? "dark" : "light";
+    }
+    const opts = sanitizeOptions(raw);
     return __spreadValues(__spreadValues({}, DEFAULT_OPTIONS), opts);
   }
   function saveOptions(opts) {
     saveJSON(STORAGE_KEY, opts);
   }
-  var DEFAULT_OPTIONS, STORAGE_KEY;
+  var DEFAULT_OPTIONS, STORAGE_KEY, OPTION_VALIDATORS;
   var init_options = __esm({
     "src/helpers/options.ts"() {
       init_storage();
@@ -121,6 +131,36 @@
         versionSidebarHeight: null
       };
       STORAGE_KEY = "gpt-script-options";
+      OPTION_VALIDATORS = {
+        theme: (v) => v === null || typeof v === "string",
+        font: (v) => v === "serif" || v === "sans-serif" || v === "monospace" || v === "custom",
+        customFont: (v) => typeof v === "string",
+        hideHeader: (v) => typeof v === "boolean",
+        hideDocs: (v) => typeof v === "boolean",
+        hideLogoText: (v) => typeof v === "boolean",
+        hideLogoImage: (v) => typeof v === "boolean",
+        hideProfile: (v) => typeof v === "boolean",
+        hideEnvironments: (v) => typeof v === "boolean",
+        threeColumnMode: (v) => typeof v === "boolean",
+        autoCheckUpdates: (v) => typeof v === "boolean",
+        showRepoSidebar: (v) => typeof v === "boolean",
+        showVersionSidebar: (v) => typeof v === "boolean",
+        clearClosedBranches: (v) => typeof v === "boolean",
+        clearMergedBranches: (v) => typeof v === "boolean",
+        clearOpenBranches: (v) => typeof v === "boolean",
+        autoArchiveMerged: (v) => typeof v === "boolean",
+        autoArchiveClosed: (v) => typeof v === "boolean",
+        historyLimit: (v) => typeof v === "number" && Number.isFinite(v),
+        disableHistory: (v) => typeof v === "boolean",
+        repoSidebarX: (v) => typeof v === "number" && Number.isFinite(v) || v === null,
+        repoSidebarY: (v) => typeof v === "number" && Number.isFinite(v) || v === null,
+        repoSidebarWidth: (v) => typeof v === "number" && Number.isFinite(v) || v === null,
+        repoSidebarHeight: (v) => typeof v === "number" && Number.isFinite(v) || v === null,
+        versionSidebarX: (v) => typeof v === "number" && Number.isFinite(v) || v === null,
+        versionSidebarY: (v) => typeof v === "number" && Number.isFinite(v) || v === null,
+        versionSidebarWidth: (v) => typeof v === "number" && Number.isFinite(v) || v === null,
+        versionSidebarHeight: (v) => typeof v === "number" && Number.isFinite(v) || v === null
+      };
     }
   });
 
@@ -224,7 +264,7 @@
   var VERSION;
   var init_version = __esm({
     "src/version.ts"() {
-      VERSION = "1.0.38";
+      VERSION = "1.0.39";
     }
   });
 

--- a/openai-codex.user.js
+++ b/openai-codex.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.0.38
+// @version      1.0.39
 // @description  Adds a prompt suggestion dropdown above the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest
@@ -84,18 +84,28 @@
   });
 
   // src/helpers/options.ts
-  function loadOptions() {
-    const opts = loadJSON(STORAGE_KEY, DEFAULT_OPTIONS);
-    const anyOpts = opts;
-    if ("dark" in anyOpts && !("theme" in anyOpts)) {
-      anyOpts.theme = anyOpts.dark ? "dark" : "light";
+  function sanitizeOptions(raw) {
+    const result = {};
+    for (const key in OPTION_VALIDATORS) {
+      const value = raw[key];
+      if (OPTION_VALIDATORS[key](value)) {
+        result[key] = value;
+      }
     }
+    return result;
+  }
+  function loadOptions() {
+    const raw = loadJSON(STORAGE_KEY, {});
+    if ("dark" in raw && !("theme" in raw)) {
+      raw.theme = raw.dark ? "dark" : "light";
+    }
+    const opts = sanitizeOptions(raw);
     return __spreadValues(__spreadValues({}, DEFAULT_OPTIONS), opts);
   }
   function saveOptions(opts) {
     saveJSON(STORAGE_KEY, opts);
   }
-  var DEFAULT_OPTIONS, STORAGE_KEY;
+  var DEFAULT_OPTIONS, STORAGE_KEY, OPTION_VALIDATORS;
   var init_options = __esm({
     "src/helpers/options.ts"() {
       init_storage();
@@ -130,6 +140,36 @@
         versionSidebarHeight: null
       };
       STORAGE_KEY = "gpt-script-options";
+      OPTION_VALIDATORS = {
+        theme: (v) => v === null || typeof v === "string",
+        font: (v) => v === "serif" || v === "sans-serif" || v === "monospace" || v === "custom",
+        customFont: (v) => typeof v === "string",
+        hideHeader: (v) => typeof v === "boolean",
+        hideDocs: (v) => typeof v === "boolean",
+        hideLogoText: (v) => typeof v === "boolean",
+        hideLogoImage: (v) => typeof v === "boolean",
+        hideProfile: (v) => typeof v === "boolean",
+        hideEnvironments: (v) => typeof v === "boolean",
+        threeColumnMode: (v) => typeof v === "boolean",
+        autoCheckUpdates: (v) => typeof v === "boolean",
+        showRepoSidebar: (v) => typeof v === "boolean",
+        showVersionSidebar: (v) => typeof v === "boolean",
+        clearClosedBranches: (v) => typeof v === "boolean",
+        clearMergedBranches: (v) => typeof v === "boolean",
+        clearOpenBranches: (v) => typeof v === "boolean",
+        autoArchiveMerged: (v) => typeof v === "boolean",
+        autoArchiveClosed: (v) => typeof v === "boolean",
+        historyLimit: (v) => typeof v === "number" && Number.isFinite(v),
+        disableHistory: (v) => typeof v === "boolean",
+        repoSidebarX: (v) => typeof v === "number" && Number.isFinite(v) || v === null,
+        repoSidebarY: (v) => typeof v === "number" && Number.isFinite(v) || v === null,
+        repoSidebarWidth: (v) => typeof v === "number" && Number.isFinite(v) || v === null,
+        repoSidebarHeight: (v) => typeof v === "number" && Number.isFinite(v) || v === null,
+        versionSidebarX: (v) => typeof v === "number" && Number.isFinite(v) || v === null,
+        versionSidebarY: (v) => typeof v === "number" && Number.isFinite(v) || v === null,
+        versionSidebarWidth: (v) => typeof v === "number" && Number.isFinite(v) || v === null,
+        versionSidebarHeight: (v) => typeof v === "number" && Number.isFinite(v) || v === null
+      };
     }
   });
 
@@ -233,7 +273,7 @@
   var VERSION;
   var init_version = __esm({
     "src/version.ts"() {
-      VERSION = "1.0.38";
+      VERSION = "1.0.39";
     }
   });
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.38",
+  "version": "1.0.39",
   "scripts": {
     "build": "node build.js",
     "test": "npm run build && node --test -r ts-node/register tests/*.test.ts"

--- a/src/header.js
+++ b/src/header.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.0.38
+// @version      1.0.39
 // @description  Adds a prompt suggestion dropdown above the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest

--- a/tests/options.test.ts
+++ b/tests/options.test.ts
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { JSDOM } from 'jsdom';
+import { loadOptions, DEFAULT_OPTIONS } from '../src/helpers/options';
+
+const STORAGE_KEY = 'gpt-script-options';
+
+test('loadOptions applies defaults for missing fields', { concurrency: false }, () => {
+  const dom = new JSDOM('', { url: 'https://example.com' });
+  (globalThis as any).localStorage = dom.window.localStorage;
+
+  dom.window.localStorage.setItem(STORAGE_KEY, JSON.stringify({ hideHeader: true }));
+  const opts = loadOptions();
+
+  assert.strictEqual(opts.hideHeader, true);
+  assert.strictEqual(opts.font, DEFAULT_OPTIONS.font);
+});
+
+test('loadOptions discards invalid and unknown values', { concurrency: false }, () => {
+  const dom = new JSDOM('', { url: 'https://example.com' });
+  (globalThis as any).localStorage = dom.window.localStorage;
+
+  const bad = { hideHeader: 'yes', font: 'papyrus', historyLimit: '100', foo: 'bar' };
+  dom.window.localStorage.setItem(STORAGE_KEY, JSON.stringify(bad));
+
+  const opts: any = loadOptions();
+  assert.strictEqual(opts.hideHeader, DEFAULT_OPTIONS.hideHeader);
+  assert.strictEqual(opts.font, DEFAULT_OPTIONS.font);
+  assert.strictEqual(opts.historyLimit, DEFAULT_OPTIONS.historyLimit);
+  assert.ok(!('foo' in opts));
+});


### PR DESCRIPTION
## Summary
- validate stored options with a schema and strip invalid entries
- discard unknown values before applying defaults
- cover corrupted and missing fields in new tests

## Testing
- `npx tsc`
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a75662821c8325954fb772adf3521f