### PR TITLE
feat: add inline suggestion editor

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -146,6 +146,191 @@
     }
   });
 
+  // src/helpers/suggestions-ui.ts
+  function renderSuggestionsUI(wrap, suggestions, handlers) {
+    wrap.innerHTML = '<h3 class="mb-1">Prompt Suggestions</h3>';
+    const table = document.createElement("table");
+    table.className = "w-full text-sm";
+    const thead = document.createElement("thead");
+    const headerRow = document.createElement("tr");
+    const textHead = document.createElement("th");
+    textHead.textContent = "Suggestion";
+    textHead.className = "text-left";
+    const actionsHead = document.createElement("th");
+    actionsHead.textContent = "Actions";
+    headerRow.appendChild(textHead);
+    headerRow.appendChild(actionsHead);
+    thead.appendChild(headerRow);
+    table.appendChild(thead);
+    const tbody = document.createElement("tbody");
+    suggestions.forEach((s, i) => {
+      const row = document.createElement("tr");
+      const cell = document.createElement("td");
+      const actions = document.createElement("td");
+      actions.className = "space-x-1";
+      let editing = false;
+      const editBtn = document.createElement("button");
+      editBtn.className = "btn relative btn-secondary btn-small";
+      editBtn.textContent = "Edit";
+      editBtn.dataset.testid = `suggestion-edit-${i}`;
+      const delBtn = document.createElement("button");
+      delBtn.className = "btn relative btn-secondary btn-small";
+      delBtn.textContent = "Remove";
+      function renderRow() {
+        cell.innerHTML = "";
+        actions.innerHTML = "";
+        if (editing) {
+          const input = document.createElement("input");
+          input.type = "text";
+          input.value = s;
+          input.className = "input input-sm w-full";
+          input.dataset.testid = "suggestion-edit-input";
+          cell.appendChild(input);
+          const saveBtn = document.createElement("button");
+          saveBtn.className = "btn relative btn-primary btn-small";
+          saveBtn.textContent = "Save";
+          saveBtn.dataset.testid = "suggestion-save";
+          const cancelBtn = document.createElement("button");
+          cancelBtn.className = "btn relative btn-secondary btn-small";
+          cancelBtn.textContent = "Cancel";
+          cancelBtn.dataset.testid = "suggestion-cancel";
+          actions.appendChild(saveBtn);
+          actions.appendChild(cancelBtn);
+          saveBtn.addEventListener("click", () => {
+            const val = input.value.trim();
+            const duplicate = suggestions.some((v, idx) => idx !== i && v === val);
+            if (!val || duplicate) {
+              input.classList.add("border-red-500");
+              return;
+            }
+            suggestions[i] = val;
+            handlers.save(suggestions);
+            renderSuggestionsUI(wrap, suggestions, handlers);
+            handlers.refresh();
+          });
+          cancelBtn.addEventListener("click", () => {
+            editing = false;
+            renderRow();
+          });
+        } else {
+          cell.textContent = s;
+          actions.appendChild(editBtn);
+          actions.appendChild(delBtn);
+        }
+      }
+      editBtn.addEventListener("click", () => {
+        editing = true;
+        renderRow();
+      });
+      delBtn.addEventListener("click", () => {
+        suggestions.splice(i, 1);
+        handlers.save(suggestions);
+        renderSuggestionsUI(wrap, suggestions, handlers);
+        handlers.refresh();
+      });
+      renderRow();
+      row.appendChild(cell);
+      row.appendChild(actions);
+      tbody.appendChild(row);
+    });
+    table.appendChild(tbody);
+    wrap.appendChild(table);
+    const addWrap = document.createElement("div");
+    addWrap.className = "flex gap-2 mt-2";
+    const addInput = document.createElement("input");
+    addInput.type = "text";
+    addInput.placeholder = "New suggestion";
+    addInput.className = "input input-sm flex-1";
+    addInput.dataset.testid = "suggestion-add-input";
+    const addBtn = document.createElement("button");
+    addBtn.className = "btn relative btn-secondary btn-small";
+    addBtn.textContent = "Add";
+    addBtn.dataset.testid = "suggestion-add-button";
+    addBtn.addEventListener("click", () => {
+      const val = addInput.value.trim();
+      const duplicate = suggestions.includes(val);
+      if (!val || duplicate) {
+        addInput.classList.add("border-red-500");
+        return;
+      }
+      suggestions.push(val);
+      handlers.save(suggestions);
+      renderSuggestionsUI(wrap, suggestions, handlers);
+      handlers.refresh();
+    });
+    addWrap.appendChild(addInput);
+    addWrap.appendChild(addBtn);
+    wrap.appendChild(addWrap);
+    const exportBtn = document.createElement("button");
+    exportBtn.className = "btn relative btn-secondary btn-small";
+    exportBtn.textContent = "Export";
+    exportBtn.addEventListener("click", () => {
+      try {
+        const blob = new Blob([JSON.stringify(suggestions, null, 2)], {
+          type: "application/json"
+        });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = "suggestions.json";
+        document.body.appendChild(a);
+        a.click();
+        URL.revokeObjectURL(url);
+        a.remove();
+      } catch (e) {
+        console.error("Failed to export suggestions", e);
+        window.alert("Failed to export suggestions");
+      }
+    });
+    wrap.appendChild(exportBtn);
+    const importBtn = document.createElement("button");
+    importBtn.className = "btn relative btn-secondary btn-small";
+    importBtn.textContent = "Import";
+    importBtn.addEventListener("click", () => {
+      const input = document.createElement("input");
+      input.type = "file";
+      input.accept = "application/json";
+      input.addEventListener("change", () => {
+        var _a;
+        const file = (_a = input.files) == null ? void 0 : _a[0];
+        if (!file) return;
+        const reader = new FileReader();
+        reader.onload = () => {
+          try {
+            const data = JSON.parse(String(reader.result));
+            if (Array.isArray(data)) {
+              const list = Array.from(
+                new Set(
+                  data.map((d) => String(d).trim()).filter((s) => s.length > 0)
+                )
+              );
+              if (list.length > 0) {
+                suggestions.splice(0, suggestions.length, ...list);
+                handlers.save(suggestions);
+                renderSuggestionsUI(wrap, suggestions, handlers);
+                handlers.refresh();
+              } else {
+                window.alert("Invalid suggestions file");
+              }
+            } else {
+              window.alert("Invalid suggestions file");
+            }
+          } catch (err) {
+            console.error("Failed to import suggestions", err);
+            window.alert("Failed to import suggestions");
+          }
+        };
+        reader.readAsText(file);
+      });
+      input.click();
+    });
+    wrap.appendChild(importBtn);
+  }
+  var init_suggestions_ui = __esm({
+    "src/helpers/suggestions-ui.ts"() {
+    }
+  });
+
   // src/helpers/history.ts
   function loadHistory() {
     return loadJSON(STORAGE_KEY3, []);
@@ -224,7 +409,7 @@
   var VERSION;
   var init_version = __esm({
     "src/version.ts"() {
-      VERSION = "1.0.38";
+      VERSION = "1.0.39";
     }
   });
 
@@ -233,6 +418,7 @@
     "src/index.ts"() {
       init_options();
       init_suggestions();
+      init_suggestions_ui();
       init_history();
       init_repos();
       init_version();
@@ -995,130 +1181,10 @@ body, html {
         }
         function renderSuggestions() {
           const wrap = modal.querySelector("#gpt-settings-suggestions");
-          wrap.innerHTML = '<h3 class="mb-1">Prompt Suggestions</h3>';
-          const table = document.createElement("table");
-          table.className = "w-full text-sm";
-          const thead = document.createElement("thead");
-          const headerRow = document.createElement("tr");
-          const textHead = document.createElement("th");
-          textHead.textContent = "Suggestion";
-          textHead.className = "text-left";
-          const actionsHead = document.createElement("th");
-          actionsHead.textContent = "Actions";
-          headerRow.appendChild(textHead);
-          headerRow.appendChild(actionsHead);
-          thead.appendChild(headerRow);
-          table.appendChild(thead);
-          const tbody = document.createElement("tbody");
-          suggestions.forEach((s, i) => {
-            const row = document.createElement("tr");
-            const cell = document.createElement("td");
-            cell.textContent = s;
-            const actions = document.createElement("td");
-            const edit = document.createElement("button");
-            edit.className = "btn relative btn-secondary btn-small";
-            edit.textContent = "Edit";
-            const del = document.createElement("button");
-            del.className = "btn relative btn-secondary btn-small";
-            del.textContent = "Remove";
-            edit.addEventListener("click", () => {
-              const inp = window.prompt("Edit suggestion:", s);
-              if (inp !== null) {
-                suggestions[i] = inp.trim();
-                saveSuggestions(suggestions);
-                renderSuggestions();
-                refreshDropdown();
-              }
-            });
-            del.addEventListener("click", () => {
-              suggestions.splice(i, 1);
-              saveSuggestions(suggestions);
-              renderSuggestions();
-              refreshDropdown();
-            });
-            actions.appendChild(edit);
-            actions.appendChild(del);
-            row.appendChild(cell);
-            row.appendChild(actions);
-            tbody.appendChild(row);
+          renderSuggestionsUI(wrap, suggestions, {
+            save: saveSuggestions,
+            refresh: refreshDropdown
           });
-          table.appendChild(tbody);
-          wrap.appendChild(table);
-          const addBtn = document.createElement("button");
-          addBtn.className = "btn relative btn-secondary btn-small";
-          addBtn.textContent = "Add";
-          addBtn.addEventListener("click", () => {
-            const inp = window.prompt("New suggestion:");
-            if (inp) {
-              suggestions.push(inp.trim());
-              saveSuggestions(suggestions);
-              renderSuggestions();
-              refreshDropdown();
-            }
-          });
-          wrap.appendChild(addBtn);
-          const exportBtn = document.createElement("button");
-          exportBtn.className = "btn relative btn-secondary btn-small";
-          exportBtn.textContent = "Export";
-          exportBtn.addEventListener("click", () => {
-            try {
-              const blob = new Blob([JSON.stringify(suggestions, null, 2)], { type: "application/json" });
-              const url = URL.createObjectURL(blob);
-              const a = document.createElement("a");
-              a.href = url;
-              a.download = "suggestions.json";
-              document.body.appendChild(a);
-              a.click();
-              URL.revokeObjectURL(url);
-              a.remove();
-            } catch (e) {
-              console.error("Failed to export suggestions", e);
-              window.alert("Failed to export suggestions");
-            }
-          });
-          wrap.appendChild(exportBtn);
-          const importBtn = document.createElement("button");
-          importBtn.className = "btn relative btn-secondary btn-small";
-          importBtn.textContent = "Import";
-          importBtn.addEventListener("click", () => {
-            const input = document.createElement("input");
-            input.type = "file";
-            input.accept = "application/json";
-            input.addEventListener("change", () => {
-              var _a;
-              const file = (_a = input.files) == null ? void 0 : _a[0];
-              if (!file) return;
-              const reader = new FileReader();
-              reader.onload = () => {
-                try {
-                  const data = JSON.parse(String(reader.result));
-                  if (Array.isArray(data)) {
-                    const list = Array.from(
-                      new Set(
-                        data.map((d) => String(d).trim()).filter((s) => s.length > 0)
-                      )
-                    );
-                    if (list.length > 0) {
-                      suggestions = list;
-                      saveSuggestions(suggestions);
-                      renderSuggestions();
-                      refreshDropdown();
-                    } else {
-                      window.alert("Invalid suggestions file");
-                    }
-                  } else {
-                    window.alert("Invalid suggestions file");
-                  }
-                } catch (err) {
-                  console.error("Failed to import suggestions", err);
-                  window.alert("Failed to import suggestions");
-                }
-              };
-              reader.readAsText(file);
-            });
-            input.click();
-          });
-          wrap.appendChild(importBtn);
         }
         function openSettings() {
           renderSuggestions();

--- a/openai-codex.user.js
+++ b/openai-codex.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.0.38
+// @version      1.0.39
 // @description  Adds a prompt suggestion dropdown above the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest
@@ -155,6 +155,191 @@
     }
   });
 
+  // src/helpers/suggestions-ui.ts
+  function renderSuggestionsUI(wrap, suggestions, handlers) {
+    wrap.innerHTML = '<h3 class="mb-1">Prompt Suggestions</h3>';
+    const table = document.createElement("table");
+    table.className = "w-full text-sm";
+    const thead = document.createElement("thead");
+    const headerRow = document.createElement("tr");
+    const textHead = document.createElement("th");
+    textHead.textContent = "Suggestion";
+    textHead.className = "text-left";
+    const actionsHead = document.createElement("th");
+    actionsHead.textContent = "Actions";
+    headerRow.appendChild(textHead);
+    headerRow.appendChild(actionsHead);
+    thead.appendChild(headerRow);
+    table.appendChild(thead);
+    const tbody = document.createElement("tbody");
+    suggestions.forEach((s, i) => {
+      const row = document.createElement("tr");
+      const cell = document.createElement("td");
+      const actions = document.createElement("td");
+      actions.className = "space-x-1";
+      let editing = false;
+      const editBtn = document.createElement("button");
+      editBtn.className = "btn relative btn-secondary btn-small";
+      editBtn.textContent = "Edit";
+      editBtn.dataset.testid = `suggestion-edit-${i}`;
+      const delBtn = document.createElement("button");
+      delBtn.className = "btn relative btn-secondary btn-small";
+      delBtn.textContent = "Remove";
+      function renderRow() {
+        cell.innerHTML = "";
+        actions.innerHTML = "";
+        if (editing) {
+          const input = document.createElement("input");
+          input.type = "text";
+          input.value = s;
+          input.className = "input input-sm w-full";
+          input.dataset.testid = "suggestion-edit-input";
+          cell.appendChild(input);
+          const saveBtn = document.createElement("button");
+          saveBtn.className = "btn relative btn-primary btn-small";
+          saveBtn.textContent = "Save";
+          saveBtn.dataset.testid = "suggestion-save";
+          const cancelBtn = document.createElement("button");
+          cancelBtn.className = "btn relative btn-secondary btn-small";
+          cancelBtn.textContent = "Cancel";
+          cancelBtn.dataset.testid = "suggestion-cancel";
+          actions.appendChild(saveBtn);
+          actions.appendChild(cancelBtn);
+          saveBtn.addEventListener("click", () => {
+            const val = input.value.trim();
+            const duplicate = suggestions.some((v, idx) => idx !== i && v === val);
+            if (!val || duplicate) {
+              input.classList.add("border-red-500");
+              return;
+            }
+            suggestions[i] = val;
+            handlers.save(suggestions);
+            renderSuggestionsUI(wrap, suggestions, handlers);
+            handlers.refresh();
+          });
+          cancelBtn.addEventListener("click", () => {
+            editing = false;
+            renderRow();
+          });
+        } else {
+          cell.textContent = s;
+          actions.appendChild(editBtn);
+          actions.appendChild(delBtn);
+        }
+      }
+      editBtn.addEventListener("click", () => {
+        editing = true;
+        renderRow();
+      });
+      delBtn.addEventListener("click", () => {
+        suggestions.splice(i, 1);
+        handlers.save(suggestions);
+        renderSuggestionsUI(wrap, suggestions, handlers);
+        handlers.refresh();
+      });
+      renderRow();
+      row.appendChild(cell);
+      row.appendChild(actions);
+      tbody.appendChild(row);
+    });
+    table.appendChild(tbody);
+    wrap.appendChild(table);
+    const addWrap = document.createElement("div");
+    addWrap.className = "flex gap-2 mt-2";
+    const addInput = document.createElement("input");
+    addInput.type = "text";
+    addInput.placeholder = "New suggestion";
+    addInput.className = "input input-sm flex-1";
+    addInput.dataset.testid = "suggestion-add-input";
+    const addBtn = document.createElement("button");
+    addBtn.className = "btn relative btn-secondary btn-small";
+    addBtn.textContent = "Add";
+    addBtn.dataset.testid = "suggestion-add-button";
+    addBtn.addEventListener("click", () => {
+      const val = addInput.value.trim();
+      const duplicate = suggestions.includes(val);
+      if (!val || duplicate) {
+        addInput.classList.add("border-red-500");
+        return;
+      }
+      suggestions.push(val);
+      handlers.save(suggestions);
+      renderSuggestionsUI(wrap, suggestions, handlers);
+      handlers.refresh();
+    });
+    addWrap.appendChild(addInput);
+    addWrap.appendChild(addBtn);
+    wrap.appendChild(addWrap);
+    const exportBtn = document.createElement("button");
+    exportBtn.className = "btn relative btn-secondary btn-small";
+    exportBtn.textContent = "Export";
+    exportBtn.addEventListener("click", () => {
+      try {
+        const blob = new Blob([JSON.stringify(suggestions, null, 2)], {
+          type: "application/json"
+        });
+        const url = URL.createObjectURL(blob);
+        const a = document.createElement("a");
+        a.href = url;
+        a.download = "suggestions.json";
+        document.body.appendChild(a);
+        a.click();
+        URL.revokeObjectURL(url);
+        a.remove();
+      } catch (e) {
+        console.error("Failed to export suggestions", e);
+        window.alert("Failed to export suggestions");
+      }
+    });
+    wrap.appendChild(exportBtn);
+    const importBtn = document.createElement("button");
+    importBtn.className = "btn relative btn-secondary btn-small";
+    importBtn.textContent = "Import";
+    importBtn.addEventListener("click", () => {
+      const input = document.createElement("input");
+      input.type = "file";
+      input.accept = "application/json";
+      input.addEventListener("change", () => {
+        var _a;
+        const file = (_a = input.files) == null ? void 0 : _a[0];
+        if (!file) return;
+        const reader = new FileReader();
+        reader.onload = () => {
+          try {
+            const data = JSON.parse(String(reader.result));
+            if (Array.isArray(data)) {
+              const list = Array.from(
+                new Set(
+                  data.map((d) => String(d).trim()).filter((s) => s.length > 0)
+                )
+              );
+              if (list.length > 0) {
+                suggestions.splice(0, suggestions.length, ...list);
+                handlers.save(suggestions);
+                renderSuggestionsUI(wrap, suggestions, handlers);
+                handlers.refresh();
+              } else {
+                window.alert("Invalid suggestions file");
+              }
+            } else {
+              window.alert("Invalid suggestions file");
+            }
+          } catch (err) {
+            console.error("Failed to import suggestions", err);
+            window.alert("Failed to import suggestions");
+          }
+        };
+        reader.readAsText(file);
+      });
+      input.click();
+    });
+    wrap.appendChild(importBtn);
+  }
+  var init_suggestions_ui = __esm({
+    "src/helpers/suggestions-ui.ts"() {
+    }
+  });
+
   // src/helpers/history.ts
   function loadHistory() {
     return loadJSON(STORAGE_KEY3, []);
@@ -233,7 +418,7 @@
   var VERSION;
   var init_version = __esm({
     "src/version.ts"() {
-      VERSION = "1.0.38";
+      VERSION = "1.0.39";
     }
   });
 
@@ -242,6 +427,7 @@
     "src/index.ts"() {
       init_options();
       init_suggestions();
+      init_suggestions_ui();
       init_history();
       init_repos();
       init_version();
@@ -1004,130 +1190,10 @@ body, html {
         }
         function renderSuggestions() {
           const wrap = modal.querySelector("#gpt-settings-suggestions");
-          wrap.innerHTML = '<h3 class="mb-1">Prompt Suggestions</h3>';
-          const table = document.createElement("table");
-          table.className = "w-full text-sm";
-          const thead = document.createElement("thead");
-          const headerRow = document.createElement("tr");
-          const textHead = document.createElement("th");
-          textHead.textContent = "Suggestion";
-          textHead.className = "text-left";
-          const actionsHead = document.createElement("th");
-          actionsHead.textContent = "Actions";
-          headerRow.appendChild(textHead);
-          headerRow.appendChild(actionsHead);
-          thead.appendChild(headerRow);
-          table.appendChild(thead);
-          const tbody = document.createElement("tbody");
-          suggestions.forEach((s, i) => {
-            const row = document.createElement("tr");
-            const cell = document.createElement("td");
-            cell.textContent = s;
-            const actions = document.createElement("td");
-            const edit = document.createElement("button");
-            edit.className = "btn relative btn-secondary btn-small";
-            edit.textContent = "Edit";
-            const del = document.createElement("button");
-            del.className = "btn relative btn-secondary btn-small";
-            del.textContent = "Remove";
-            edit.addEventListener("click", () => {
-              const inp = window.prompt("Edit suggestion:", s);
-              if (inp !== null) {
-                suggestions[i] = inp.trim();
-                saveSuggestions(suggestions);
-                renderSuggestions();
-                refreshDropdown();
-              }
-            });
-            del.addEventListener("click", () => {
-              suggestions.splice(i, 1);
-              saveSuggestions(suggestions);
-              renderSuggestions();
-              refreshDropdown();
-            });
-            actions.appendChild(edit);
-            actions.appendChild(del);
-            row.appendChild(cell);
-            row.appendChild(actions);
-            tbody.appendChild(row);
+          renderSuggestionsUI(wrap, suggestions, {
+            save: saveSuggestions,
+            refresh: refreshDropdown
           });
-          table.appendChild(tbody);
-          wrap.appendChild(table);
-          const addBtn = document.createElement("button");
-          addBtn.className = "btn relative btn-secondary btn-small";
-          addBtn.textContent = "Add";
-          addBtn.addEventListener("click", () => {
-            const inp = window.prompt("New suggestion:");
-            if (inp) {
-              suggestions.push(inp.trim());
-              saveSuggestions(suggestions);
-              renderSuggestions();
-              refreshDropdown();
-            }
-          });
-          wrap.appendChild(addBtn);
-          const exportBtn = document.createElement("button");
-          exportBtn.className = "btn relative btn-secondary btn-small";
-          exportBtn.textContent = "Export";
-          exportBtn.addEventListener("click", () => {
-            try {
-              const blob = new Blob([JSON.stringify(suggestions, null, 2)], { type: "application/json" });
-              const url = URL.createObjectURL(blob);
-              const a = document.createElement("a");
-              a.href = url;
-              a.download = "suggestions.json";
-              document.body.appendChild(a);
-              a.click();
-              URL.revokeObjectURL(url);
-              a.remove();
-            } catch (e) {
-              console.error("Failed to export suggestions", e);
-              window.alert("Failed to export suggestions");
-            }
-          });
-          wrap.appendChild(exportBtn);
-          const importBtn = document.createElement("button");
-          importBtn.className = "btn relative btn-secondary btn-small";
-          importBtn.textContent = "Import";
-          importBtn.addEventListener("click", () => {
-            const input = document.createElement("input");
-            input.type = "file";
-            input.accept = "application/json";
-            input.addEventListener("change", () => {
-              var _a;
-              const file = (_a = input.files) == null ? void 0 : _a[0];
-              if (!file) return;
-              const reader = new FileReader();
-              reader.onload = () => {
-                try {
-                  const data = JSON.parse(String(reader.result));
-                  if (Array.isArray(data)) {
-                    const list = Array.from(
-                      new Set(
-                        data.map((d) => String(d).trim()).filter((s) => s.length > 0)
-                      )
-                    );
-                    if (list.length > 0) {
-                      suggestions = list;
-                      saveSuggestions(suggestions);
-                      renderSuggestions();
-                      refreshDropdown();
-                    } else {
-                      window.alert("Invalid suggestions file");
-                    }
-                  } else {
-                    window.alert("Invalid suggestions file");
-                  }
-                } catch (err) {
-                  console.error("Failed to import suggestions", err);
-                  window.alert("Failed to import suggestions");
-                }
-              };
-              reader.readAsText(file);
-            });
-            input.click();
-          });
-          wrap.appendChild(importBtn);
         }
         function openSettings() {
           renderSuggestions();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.38",
+  "version": "1.0.39",
   "scripts": {
     "build": "node build.js",
     "test": "npm run build && node --test -r ts-node/register tests/*.test.ts"

--- a/src/header.js
+++ b/src/header.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.0.38
+// @version      1.0.39
 // @description  Adds a prompt suggestion dropdown above the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest

--- a/src/helpers/suggestions-ui.ts
+++ b/src/helpers/suggestions-ui.ts
@@ -1,0 +1,215 @@
+// @ts-nocheck
+export interface SuggestionsUIHandlers {
+  save(list: string[]): void;
+  refresh(): void;
+}
+
+export function renderSuggestionsUI(
+  wrap: HTMLElement,
+  suggestions: string[],
+  handlers: SuggestionsUIHandlers
+): void {
+  wrap.innerHTML = '<h3 class="mb-1">Prompt Suggestions</h3>';
+
+  const table = document.createElement('table');
+  table.className = 'w-full text-sm';
+
+  const thead = document.createElement('thead');
+  const headerRow = document.createElement('tr');
+  const textHead = document.createElement('th');
+  textHead.textContent = 'Suggestion';
+  textHead.className = 'text-left';
+  const actionsHead = document.createElement('th');
+  actionsHead.textContent = 'Actions';
+  headerRow.appendChild(textHead);
+  headerRow.appendChild(actionsHead);
+  thead.appendChild(headerRow);
+  table.appendChild(thead);
+
+  const tbody = document.createElement('tbody');
+  suggestions.forEach((s, i) => {
+    const row = document.createElement('tr');
+    const cell = document.createElement('td');
+    const actions = document.createElement('td');
+    actions.className = 'space-x-1';
+
+    let editing = false;
+
+    const editBtn = document.createElement('button');
+    editBtn.className = 'btn relative btn-secondary btn-small';
+    editBtn.textContent = 'Edit';
+    editBtn.dataset.testid = `suggestion-edit-${i}`;
+
+    const delBtn = document.createElement('button');
+    delBtn.className = 'btn relative btn-secondary btn-small';
+    delBtn.textContent = 'Remove';
+
+    function renderRow() {
+      cell.innerHTML = '';
+      actions.innerHTML = '';
+      if (editing) {
+        const input = document.createElement('input');
+        input.type = 'text';
+        input.value = s;
+        input.className = 'input input-sm w-full';
+        input.dataset.testid = 'suggestion-edit-input';
+        cell.appendChild(input);
+
+        const saveBtn = document.createElement('button');
+        saveBtn.className = 'btn relative btn-primary btn-small';
+        saveBtn.textContent = 'Save';
+        saveBtn.dataset.testid = 'suggestion-save';
+
+        const cancelBtn = document.createElement('button');
+        cancelBtn.className = 'btn relative btn-secondary btn-small';
+        cancelBtn.textContent = 'Cancel';
+        cancelBtn.dataset.testid = 'suggestion-cancel';
+
+        actions.appendChild(saveBtn);
+        actions.appendChild(cancelBtn);
+
+        saveBtn.addEventListener('click', () => {
+          const val = input.value.trim();
+          const duplicate = suggestions.some((v, idx) => idx !== i && v === val);
+          if (!val || duplicate) {
+            input.classList.add('border-red-500');
+            return;
+          }
+          suggestions[i] = val;
+          handlers.save(suggestions);
+          renderSuggestionsUI(wrap, suggestions, handlers);
+          handlers.refresh();
+        });
+
+        cancelBtn.addEventListener('click', () => {
+          editing = false;
+          renderRow();
+        });
+      } else {
+        cell.textContent = s;
+        actions.appendChild(editBtn);
+        actions.appendChild(delBtn);
+      }
+    }
+
+    editBtn.addEventListener('click', () => {
+      editing = true;
+      renderRow();
+    });
+
+    delBtn.addEventListener('click', () => {
+      suggestions.splice(i, 1);
+      handlers.save(suggestions);
+      renderSuggestionsUI(wrap, suggestions, handlers);
+      handlers.refresh();
+    });
+
+    renderRow();
+
+    row.appendChild(cell);
+    row.appendChild(actions);
+    tbody.appendChild(row);
+  });
+
+  table.appendChild(tbody);
+  wrap.appendChild(table);
+
+  const addWrap = document.createElement('div');
+  addWrap.className = 'flex gap-2 mt-2';
+
+  const addInput = document.createElement('input');
+  addInput.type = 'text';
+  addInput.placeholder = 'New suggestion';
+  addInput.className = 'input input-sm flex-1';
+  addInput.dataset.testid = 'suggestion-add-input';
+
+  const addBtn = document.createElement('button');
+  addBtn.className = 'btn relative btn-secondary btn-small';
+  addBtn.textContent = 'Add';
+  addBtn.dataset.testid = 'suggestion-add-button';
+
+  addBtn.addEventListener('click', () => {
+    const val = addInput.value.trim();
+    const duplicate = suggestions.includes(val);
+    if (!val || duplicate) {
+      addInput.classList.add('border-red-500');
+      return;
+    }
+    suggestions.push(val);
+    handlers.save(suggestions);
+    renderSuggestionsUI(wrap, suggestions, handlers);
+    handlers.refresh();
+  });
+
+  addWrap.appendChild(addInput);
+  addWrap.appendChild(addBtn);
+  wrap.appendChild(addWrap);
+
+  const exportBtn = document.createElement('button');
+  exportBtn.className = 'btn relative btn-secondary btn-small';
+  exportBtn.textContent = 'Export';
+  exportBtn.addEventListener('click', () => {
+    try {
+      const blob = new Blob([JSON.stringify(suggestions, null, 2)], {
+        type: 'application/json',
+      });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = 'suggestions.json';
+      document.body.appendChild(a);
+      a.click();
+      URL.revokeObjectURL(url);
+      a.remove();
+    } catch (e) {
+      console.error('Failed to export suggestions', e);
+      window.alert('Failed to export suggestions');
+    }
+  });
+  wrap.appendChild(exportBtn);
+
+  const importBtn = document.createElement('button');
+  importBtn.className = 'btn relative btn-secondary btn-small';
+  importBtn.textContent = 'Import';
+  importBtn.addEventListener('click', () => {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = 'application/json';
+    input.addEventListener('change', () => {
+      const file = input.files?.[0];
+      if (!file) return;
+      const reader = new FileReader();
+      reader.onload = () => {
+        try {
+          const data = JSON.parse(String(reader.result));
+          if (Array.isArray(data)) {
+            const list = Array.from(
+              new Set(
+                data
+                  .map((d) => String(d).trim())
+                  .filter((s) => s.length > 0)
+              )
+            );
+            if (list.length > 0) {
+              suggestions.splice(0, suggestions.length, ...list);
+              handlers.save(suggestions);
+              renderSuggestionsUI(wrap, suggestions, handlers);
+              handlers.refresh();
+            } else {
+              window.alert('Invalid suggestions file');
+            }
+          } else {
+            window.alert('Invalid suggestions file');
+          }
+        } catch (err) {
+          console.error('Failed to import suggestions', err);
+          window.alert('Failed to import suggestions');
+        }
+      };
+      reader.readAsText(file);
+    });
+    input.click();
+  });
+  wrap.appendChild(importBtn);
+}
+

--- a/tests/suggestions-ui.test.ts
+++ b/tests/suggestions-ui.test.ts
@@ -1,0 +1,43 @@
+// @ts-nocheck
+import test from 'node:test';
+import assert from 'node:assert';
+import { JSDOM } from 'jsdom';
+import { renderSuggestionsUI } from '../src/helpers/suggestions-ui';
+
+test('adds suggestion via inline form', { concurrency: false }, () => {
+  const dom = new JSDOM('<div id="wrap"></div>');
+  (globalThis as any).window = dom.window;
+  (globalThis as any).document = dom.window.document;
+  const wrap = dom.window.document.getElementById('wrap');
+  const suggestions = ['foo'];
+  let saved = [];
+  renderSuggestionsUI(wrap, suggestions, {
+    save: (list) => { saved = list.slice(); },
+    refresh: () => {},
+  });
+  const input = wrap.querySelector('[data-testid="suggestion-add-input"]');
+  input.value = 'bar';
+  wrap.querySelector('[data-testid="suggestion-add-button"]').dispatchEvent(new dom.window.Event('click'));
+  assert.deepStrictEqual(suggestions, ['foo', 'bar']);
+  assert.deepStrictEqual(saved, ['foo', 'bar']);
+});
+
+test('edits suggestion inline with validation', { concurrency: false }, () => {
+  const dom = new JSDOM('<div id="wrap"></div>');
+  (globalThis as any).window = dom.window;
+  (globalThis as any).document = dom.window.document;
+  const wrap = dom.window.document.getElementById('wrap');
+  const suggestions = ['foo', 'bar'];
+  renderSuggestionsUI(wrap, suggestions, { save: () => {}, refresh: () => {} });
+  wrap.querySelector('[data-testid="suggestion-edit-0"]').dispatchEvent(new dom.window.Event('click'));
+  const editInput = wrap.querySelector('[data-testid="suggestion-edit-input"]');
+  const saveBtn = wrap.querySelector('[data-testid="suggestion-save"]');
+  // attempt duplicate
+  editInput.value = 'bar';
+  saveBtn.dispatchEvent(new dom.window.Event('click'));
+  assert.deepStrictEqual(suggestions, ['foo', 'bar']);
+  // valid edit
+  editInput.value = 'baz';
+  saveBtn.dispatchEvent(new dom.window.Event('click'));
+  assert.deepStrictEqual(suggestions, ['baz', 'bar']);
+});


### PR DESCRIPTION
## Summary
- replace blocking `window.prompt` usage with inline suggestion editor
- validate suggestion edits and additions, avoiding duplicates
- cover new editing workflow with tests and bump version

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a7566856d083259047df5036bc8c6f