### PR TITLE
fix: improve header auto-healing

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -274,7 +274,7 @@
   var VERSION;
   var init_version = __esm({
     "src/version.ts"() {
-      VERSION = "1.0.40";
+      VERSION = "1.0.41";
     }
   });
 
@@ -601,12 +601,9 @@ body, html {
         }
         function toggleHeader(hide) {
           const targetTexts = ["What are we coding next?", "What should we code next?"];
-          let node = document.querySelector("h1.mb-4.pt-4.text-2xl");
-          if (!node || !targetTexts.some((t) => {
-            var _a;
-            return (_a = node.textContent) == null ? void 0 : _a.includes(t);
-          })) {
-            node = findByText("What should we code next?");
+          let node = targetTexts.map((t) => findByText(t)).find(Boolean);
+          if (!node) {
+            node = document.querySelector("h1.mb-4.pt-4.text-2xl");
           }
           if (node && targetTexts.some((t) => {
             var _a;

--- a/openai-codex.user.js
+++ b/openai-codex.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.0.40
+// @version      1.0.41
 // @description  Adds a prompt suggestion dropdown inside the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest
@@ -283,7 +283,7 @@
   var VERSION;
   var init_version = __esm({
     "src/version.ts"() {
-      VERSION = "1.0.40";
+      VERSION = "1.0.41";
     }
   });
 
@@ -610,12 +610,9 @@ body, html {
         }
         function toggleHeader(hide) {
           const targetTexts = ["What are we coding next?", "What should we code next?"];
-          let node = document.querySelector("h1.mb-4.pt-4.text-2xl");
-          if (!node || !targetTexts.some((t) => {
-            var _a;
-            return (_a = node.textContent) == null ? void 0 : _a.includes(t);
-          })) {
-            node = findByText("What should we code next?");
+          let node = targetTexts.map((t) => findByText(t)).find(Boolean);
+          if (!node) {
+            node = document.querySelector("h1.mb-4.pt-4.text-2xl");
           }
           if (node && targetTexts.some((t) => {
             var _a;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.40",
+  "version": "1.0.41",
   "scripts": {
     "build": "node build.js",
     "test": "npm run build && node --test -r ts-node/register tests/*.test.ts"

--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ A floating gear icon is added to the side of the page. Clicking it opens a modal
 where you can manage your prompt suggestions and toggle various UI options:
 
 * Switch between Light, Dark and OLED themes.
-* Hide the “What should we code next?” header.
+* Hide the “What are we coding next?” or “What should we code next?” header.
 * Hide the “Docs” navigation link.
 * Hide the "Environments" button.
 * Toggle the repository sidebar that lists detected repositories.

--- a/src/header.js
+++ b/src/header.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.0.40
+// @version      1.0.41
 // @description  Adds a prompt suggestion dropdown inside the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest

--- a/src/index.ts
+++ b/src/index.ts
@@ -337,9 +337,9 @@ body, html {
 
     function toggleHeader(hide) {
         const targetTexts = ['What are we coding next?', 'What should we code next?'];
-        let node = document.querySelector('h1.mb-4.pt-4.text-2xl');
-        if (!node || !targetTexts.some(t => node.textContent?.includes(t))) {
-            node = findByText('What should we code next?');
+        let node = targetTexts.map(t => findByText(t)).find(Boolean);
+        if (!node) {
+            node = document.querySelector('h1.mb-4.pt-4.text-2xl');
         }
         if (node && targetTexts.some(t => node.textContent?.includes(t))) {
             node.style.display = hide ? 'none' : '';


### PR DESCRIPTION
## Summary
- search for “What are we coding next?” or “What should we code next?” header text before falling back to a selector
- document both header variants and bump version to 1.0.41

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ad80599f4c83258f94a720cbbdf220