### PR TITLE
feat: hide text-3xl headers on toggle

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -274,7 +274,7 @@
   var VERSION;
   var init_version = __esm({
     "src/version.ts"() {
-      VERSION = "1.0.42";
+      VERSION = "1.0.43";
     }
   });
 
@@ -609,6 +609,10 @@ body, html {
           if (node) {
             node.style.display = hide ? "none" : "";
           }
+          const headers = document.querySelectorAll(".text-3xl");
+          headers.forEach((el) => {
+            el.style.display = hide ? "none" : "";
+          });
         }
         function toggleDocs(hide) {
           const links = Array.from(document.querySelectorAll("a")).filter((a) => a.textContent && a.textContent.includes("Docs"));

--- a/openai-codex.user.js
+++ b/openai-codex.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.0.42
+// @version      1.0.43
 // @description  Adds a prompt suggestion dropdown inside the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest
@@ -283,7 +283,7 @@
   var VERSION;
   var init_version = __esm({
     "src/version.ts"() {
-      VERSION = "1.0.42";
+      VERSION = "1.0.43";
     }
   });
 
@@ -618,6 +618,10 @@ body, html {
           if (node) {
             node.style.display = hide ? "none" : "";
           }
+          const headers = document.querySelectorAll(".text-3xl");
+          headers.forEach((el) => {
+            el.style.display = hide ? "none" : "";
+          });
         }
         function toggleDocs(hide) {
           const links = Array.from(document.querySelectorAll("a")).filter((a) => a.textContent && a.textContent.includes("Docs"));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.42",
+  "version": "1.0.43",
   "scripts": {
     "build": "node build.js",
     "test": "npm run build && node --test -r ts-node/register tests/*.test.ts"

--- a/src/header.js
+++ b/src/header.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.0.42
+// @version      1.0.43
 // @description  Adds a prompt suggestion dropdown inside the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest

--- a/src/index.ts
+++ b/src/index.ts
@@ -346,6 +346,11 @@ body, html {
         if (node) {
             node.style.display = hide ? 'none' : '';
         }
+
+        const headers = document.querySelectorAll('.text-3xl');
+        headers.forEach(el => {
+            (el as HTMLElement).style.display = hide ? 'none' : '';
+        });
     }
 
     function toggleDocs(hide) {


### PR DESCRIPTION
## Summary
- hide elements with `text-3xl` class when header is toggled
- bump version to 1.0.43

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68adf894b6fc8325972fc6d99c4d863e