### PR TITLE
Restrict header toggle to body h1

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -274,7 +274,7 @@
   var VERSION;
   var init_version = __esm({
     "src/version.ts"() {
-      VERSION = "1.0.45";
+      VERSION = "1.0.46";
     }
   });
 
@@ -595,21 +595,8 @@ body, html {
         let options = loadOptions();
         let history = loadHistory();
         let historyQuery = "";
-        function findByText(text) {
-          const elements = Array.from(document.querySelectorAll("body *"));
-          return elements.find((el) => el.textContent && el.textContent.includes(text)) || null;
-        }
         function toggleHeader(hide) {
-          const targetTexts = ["What are we coding next?", "What should we code next?"];
-          const node = targetTexts.map((t) => findByText(t)).find(Boolean);
-          if (node) {
-            node.classList.forEach((cls) => {
-              document.querySelectorAll(`.${cls}`).forEach((el) => {
-                el.style.display = hide ? "none" : "";
-              });
-            });
-          }
-          const headers = document.querySelectorAll(".text-3xl");
+          const headers = document.querySelectorAll("body h1");
           headers.forEach((el) => {
             el.style.display = hide ? "none" : "";
           });

--- a/openai-codex.user.js
+++ b/openai-codex.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.0.45
+// @version      1.0.46
 // @description  Adds a prompt suggestion dropdown inside the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest
@@ -283,7 +283,7 @@
   var VERSION;
   var init_version = __esm({
     "src/version.ts"() {
-      VERSION = "1.0.45";
+      VERSION = "1.0.46";
     }
   });
 
@@ -604,21 +604,8 @@ body, html {
         let options = loadOptions();
         let history = loadHistory();
         let historyQuery = "";
-        function findByText(text) {
-          const elements = Array.from(document.querySelectorAll("body *"));
-          return elements.find((el) => el.textContent && el.textContent.includes(text)) || null;
-        }
         function toggleHeader(hide) {
-          const targetTexts = ["What are we coding next?", "What should we code next?"];
-          const node = targetTexts.map((t) => findByText(t)).find(Boolean);
-          if (node) {
-            node.classList.forEach((cls) => {
-              document.querySelectorAll(`.${cls}`).forEach((el) => {
-                el.style.display = hide ? "none" : "";
-              });
-            });
-          }
-          const headers = document.querySelectorAll(".text-3xl");
+          const headers = document.querySelectorAll("body h1");
           headers.forEach((el) => {
             el.style.display = hide ? "none" : "";
           });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.45",
+  "version": "1.0.46",
   "scripts": {
     "build": "node build.js",
     "test": "npm run build && node --test -r ts-node/register tests/*.test.ts"

--- a/src/header.js
+++ b/src/header.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.0.45
+// @version      1.0.46
 // @description  Adds a prompt suggestion dropdown inside the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest

--- a/src/index.ts
+++ b/src/index.ts
@@ -329,25 +329,10 @@ body, html {
 
 
 
-
-    function findByText(text) {
-        const elements = Array.from(document.querySelectorAll('body *'));
-        return elements.find(el => el.textContent && el.textContent.includes(text)) || null;
-    }
-
     function toggleHeader(hide) {
-        const targetTexts = ['What are we coding next?', 'What should we code next?'];
-        const node = targetTexts.map(t => findByText(t)).find(Boolean) as HTMLElement | null;
-        if (node) {
-            node.classList.forEach(cls => {
-                document.querySelectorAll(`.${cls}`).forEach(el => {
-                    (el as HTMLElement).style.display = hide ? 'none' : '';
-                });
-            });
-        }
-        const headers = document.querySelectorAll(".text-3xl");
+        const headers = document.querySelectorAll('body h1');
         headers.forEach((el) => {
-            (el as HTMLElement).style.display = hide ? "none" : "";
+            (el as HTMLElement).style.display = hide ? 'none' : '';
         });
     }
 

--- a/tests/header.test.ts
+++ b/tests/header.test.ts
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { JSDOM } from 'jsdom';
+
+// Ensure toggling header hides only h1 elements
+
+test('hides only h1 elements when header is toggled', async () => {
+  const html = `<!doctype html><html><head></head><body>
+    <h1 id="main">Title</h1>
+    <div class="text-3xl" id="div">Not Header</div>
+    <h2 id="secondary">Subtitle</h2>
+  </body></html>`;
+  const dom = new JSDOM(html, { url: 'https://example.com' });
+  (globalThis as any).window = dom.window;
+  (globalThis as any).document = dom.window.document;
+  (globalThis as any).localStorage = dom.window.localStorage;
+  (globalThis as any).MutationObserver = dom.window.MutationObserver;
+
+  dom.window.localStorage.setItem('gpt-script-options', JSON.stringify({ hideHeader: true }));
+
+  await import('../src/index');
+
+  const h1 = dom.window.document.getElementById('main') as HTMLElement;
+  const div = dom.window.document.getElementById('div') as HTMLElement;
+  const h2 = dom.window.document.getElementById('secondary') as HTMLElement;
+
+  assert.strictEqual(h1.style.display, 'none');
+  assert.notStrictEqual(div.style.display, 'none');
+  assert.notStrictEqual(h2.style.display, 'none');
+});


### PR DESCRIPTION
## Summary
- simplify header toggle to hide only `<h1>` elements inside the page body
- test header toggle to ensure only `<h1>` is affected
- bump version to 1.0.46

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68adfd87b0c88325b8c2c8100899a919