### PR TITLE
Handle renaming of Environments button to Settings

### DIFF
--- a/dist/helpers/options.js
+++ b/dist/helpers/options.js
@@ -13,7 +13,7 @@ exports.DEFAULT_OPTIONS = {
     hideLogoText: false,
     hideLogoImage: false,
     hideProfile: false,
-    hideEnvironments: false,
+    hideSettings: false,
     threeColumnMode: false,
     autoCheckUpdates: false,
     showRepoSidebar: true,
@@ -44,7 +44,7 @@ const OPTION_VALIDATORS = {
     hideLogoText: (v) => typeof v === 'boolean',
     hideLogoImage: (v) => typeof v === 'boolean',
     hideProfile: (v) => typeof v === 'boolean',
-    hideEnvironments: (v) => typeof v === 'boolean',
+    hideSettings: (v) => typeof v === 'boolean',
     threeColumnMode: (v) => typeof v === 'boolean',
     autoCheckUpdates: (v) => typeof v === 'boolean',
     showRepoSidebar: (v) => typeof v === 'boolean',
@@ -79,6 +79,10 @@ function loadOptions() {
     const raw = (0, storage_1.loadJSON)(STORAGE_KEY, {});
     if ('dark' in raw && !('theme' in raw)) {
         raw.theme = raw.dark ? 'dark' : 'light';
+    }
+    if ('hideEnvironments' in raw && !('hideSettings' in raw)) {
+        raw.hideSettings = raw.hideEnvironments;
+        delete raw.hideEnvironments;
     }
     const opts = sanitizeOptions(raw);
     return Object.assign(Object.assign({}, exports.DEFAULT_OPTIONS), opts);

--- a/dist/index.js
+++ b/dist/index.js
@@ -98,6 +98,10 @@
     if ("dark" in raw && !("theme" in raw)) {
       raw.theme = raw.dark ? "dark" : "light";
     }
+    if ("hideEnvironments" in raw && !("hideSettings" in raw)) {
+      raw.hideSettings = raw.hideEnvironments;
+      delete raw.hideEnvironments;
+    }
     const opts = sanitizeOptions(raw);
     return __spreadValues(__spreadValues({}, DEFAULT_OPTIONS), opts);
   }
@@ -117,7 +121,7 @@
         hideLogoText: false,
         hideLogoImage: false,
         hideProfile: false,
-        hideEnvironments: false,
+        hideSettings: false,
         threeColumnMode: false,
         autoCheckUpdates: false,
         showRepoSidebar: true,
@@ -148,7 +152,7 @@
         hideLogoText: (v) => typeof v === "boolean",
         hideLogoImage: (v) => typeof v === "boolean",
         hideProfile: (v) => typeof v === "boolean",
-        hideEnvironments: (v) => typeof v === "boolean",
+        hideSettings: (v) => typeof v === "boolean",
         threeColumnMode: (v) => typeof v === "boolean",
         autoCheckUpdates: (v) => typeof v === "boolean",
         showRepoSidebar: (v) => typeof v === "boolean",
@@ -274,7 +278,7 @@
   var VERSION;
   var init_version = __esm({
     "src/version.ts"() {
-      VERSION = "1.0.46";
+      VERSION = "1.0.47";
     }
   });
 
@@ -621,8 +625,8 @@ body, html {
           const node = document.querySelector('[aria-label*="Profile" i], [data-testid*="profile" i], [class*="profile" i], [class*="avatar" i]');
           if (node) node.style.display = hide ? "none" : "";
         }
-        function toggleEnvironments(hide) {
-          const link = document.querySelector('a[href="/codex/settings/environments"]');
+        function toggleSettingsButton(hide) {
+          const link = document.querySelector('a[href="/codex/settings"]');
           if (link) link.style.display = hide ? "none" : "";
         }
         function makeSidebarInteractive(el, prefix) {
@@ -756,7 +760,7 @@ body, html {
           toggleLogoText(options.hideLogoText);
           toggleLogoImage(options.hideLogoImage);
           toggleProfile(options.hideProfile);
-          toggleEnvironments(options.hideEnvironments);
+          toggleSettingsButton(options.hideSettings);
           toggleRepoSidebar(options.showRepoSidebar);
           toggleVersionSidebar(options.showVersionSidebar);
           if (options.threeColumnMode) {
@@ -866,7 +870,7 @@ body, html {
           document.createElement("br"),
           createCheckbox("gpt-setting-profile", "Hide profile icon"),
           document.createElement("br"),
-          createCheckbox("gpt-setting-environments", "Hide environments button"),
+          createCheckbox("gpt-setting-settings-button", "Hide Settings button"),
           document.createElement("br"),
           createCheckbox("gpt-setting-three-column", "3 column layout")
         ]);
@@ -1288,7 +1292,7 @@ body, html {
           modal.querySelector("#gpt-setting-logo-text").checked = options.hideLogoText;
           modal.querySelector("#gpt-setting-logo-image").checked = options.hideLogoImage;
           modal.querySelector("#gpt-setting-profile").checked = options.hideProfile;
-          modal.querySelector("#gpt-setting-environments").checked = options.hideEnvironments;
+          modal.querySelector("#gpt-setting-settings-button").checked = options.hideSettings;
           modal.querySelector("#gpt-setting-three-column").checked = options.threeColumnMode;
           modal.querySelector("#gpt-setting-auto-updates").checked = options.autoCheckUpdates;
           modal.querySelector("#gpt-setting-disable-history").checked = options.disableHistory;
@@ -1421,8 +1425,8 @@ body, html {
           saveOptions(options);
           applyOptions();
         });
-        modal.querySelector("#gpt-setting-environments").addEventListener("change", (e) => {
-          options.hideEnvironments = e.target.checked;
+        modal.querySelector("#gpt-setting-settings-button").addEventListener("change", (e) => {
+          options.hideSettings = e.target.checked;
           saveOptions(options);
           applyOptions();
         });
@@ -1492,7 +1496,7 @@ body, html {
           toggleLogoText(options.hideLogoText);
           toggleLogoImage(options.hideLogoImage);
           toggleProfile(options.hideProfile);
-          toggleEnvironments(options.hideEnvironments);
+          toggleSettingsButton(options.hideSettings);
           toggleRepoSidebar(options.showRepoSidebar);
           toggleVersionSidebar(options.showVersionSidebar);
         });

--- a/openai-codex.user.js
+++ b/openai-codex.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.0.46
+// @version      1.0.47
 // @description  Adds a prompt suggestion dropdown inside the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest
@@ -107,6 +107,10 @@
     if ("dark" in raw && !("theme" in raw)) {
       raw.theme = raw.dark ? "dark" : "light";
     }
+    if ("hideEnvironments" in raw && !("hideSettings" in raw)) {
+      raw.hideSettings = raw.hideEnvironments;
+      delete raw.hideEnvironments;
+    }
     const opts = sanitizeOptions(raw);
     return __spreadValues(__spreadValues({}, DEFAULT_OPTIONS), opts);
   }
@@ -126,7 +130,7 @@
         hideLogoText: false,
         hideLogoImage: false,
         hideProfile: false,
-        hideEnvironments: false,
+        hideSettings: false,
         threeColumnMode: false,
         autoCheckUpdates: false,
         showRepoSidebar: true,
@@ -157,7 +161,7 @@
         hideLogoText: (v) => typeof v === "boolean",
         hideLogoImage: (v) => typeof v === "boolean",
         hideProfile: (v) => typeof v === "boolean",
-        hideEnvironments: (v) => typeof v === "boolean",
+        hideSettings: (v) => typeof v === "boolean",
         threeColumnMode: (v) => typeof v === "boolean",
         autoCheckUpdates: (v) => typeof v === "boolean",
         showRepoSidebar: (v) => typeof v === "boolean",
@@ -283,7 +287,7 @@
   var VERSION;
   var init_version = __esm({
     "src/version.ts"() {
-      VERSION = "1.0.46";
+      VERSION = "1.0.47";
     }
   });
 
@@ -630,8 +634,8 @@ body, html {
           const node = document.querySelector('[aria-label*="Profile" i], [data-testid*="profile" i], [class*="profile" i], [class*="avatar" i]');
           if (node) node.style.display = hide ? "none" : "";
         }
-        function toggleEnvironments(hide) {
-          const link = document.querySelector('a[href="/codex/settings/environments"]');
+        function toggleSettingsButton(hide) {
+          const link = document.querySelector('a[href="/codex/settings"]');
           if (link) link.style.display = hide ? "none" : "";
         }
         function makeSidebarInteractive(el, prefix) {
@@ -765,7 +769,7 @@ body, html {
           toggleLogoText(options.hideLogoText);
           toggleLogoImage(options.hideLogoImage);
           toggleProfile(options.hideProfile);
-          toggleEnvironments(options.hideEnvironments);
+          toggleSettingsButton(options.hideSettings);
           toggleRepoSidebar(options.showRepoSidebar);
           toggleVersionSidebar(options.showVersionSidebar);
           if (options.threeColumnMode) {
@@ -875,7 +879,7 @@ body, html {
           document.createElement("br"),
           createCheckbox("gpt-setting-profile", "Hide profile icon"),
           document.createElement("br"),
-          createCheckbox("gpt-setting-environments", "Hide environments button"),
+          createCheckbox("gpt-setting-settings-button", "Hide Settings button"),
           document.createElement("br"),
           createCheckbox("gpt-setting-three-column", "3 column layout")
         ]);
@@ -1297,7 +1301,7 @@ body, html {
           modal.querySelector("#gpt-setting-logo-text").checked = options.hideLogoText;
           modal.querySelector("#gpt-setting-logo-image").checked = options.hideLogoImage;
           modal.querySelector("#gpt-setting-profile").checked = options.hideProfile;
-          modal.querySelector("#gpt-setting-environments").checked = options.hideEnvironments;
+          modal.querySelector("#gpt-setting-settings-button").checked = options.hideSettings;
           modal.querySelector("#gpt-setting-three-column").checked = options.threeColumnMode;
           modal.querySelector("#gpt-setting-auto-updates").checked = options.autoCheckUpdates;
           modal.querySelector("#gpt-setting-disable-history").checked = options.disableHistory;
@@ -1430,8 +1434,8 @@ body, html {
           saveOptions(options);
           applyOptions();
         });
-        modal.querySelector("#gpt-setting-environments").addEventListener("change", (e) => {
-          options.hideEnvironments = e.target.checked;
+        modal.querySelector("#gpt-setting-settings-button").addEventListener("change", (e) => {
+          options.hideSettings = e.target.checked;
           saveOptions(options);
           applyOptions();
         });
@@ -1501,7 +1505,7 @@ body, html {
           toggleLogoText(options.hideLogoText);
           toggleLogoImage(options.hideLogoImage);
           toggleProfile(options.hideProfile);
-          toggleEnvironments(options.hideEnvironments);
+          toggleSettingsButton(options.hideSettings);
           toggleRepoSidebar(options.showRepoSidebar);
           toggleVersionSidebar(options.showVersionSidebar);
         });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.39",
+  "version": "1.0.47",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openai-codex-userscript",
-      "version": "1.0.39",
+      "version": "1.0.47",
       "license": "ISC",
       "devDependencies": {
         "esbuild": "^0.25.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.46",
+  "version": "1.0.47",
   "scripts": {
     "build": "node build.js",
     "test": "npm run build && node --test -r ts-node/register tests/*.test.ts"

--- a/readme.md
+++ b/readme.md
@@ -21,7 +21,7 @@ where you can manage your prompt suggestions and toggle various UI options:
 * Switch between Light, Dark and OLED themes.
 * Hide the “What are we coding next?” or “What should we code next?” header.
 * Hide the “Docs” navigation link.
-* Hide the "Environments" button.
+* Hide the "Settings" button.
 * Toggle the repository sidebar that lists detected repositories.
 * Toggle the version sidebar that displays branches for the selected repository.
 * Enable auto-archiving when a task is merged or closed.

--- a/src/header.js
+++ b/src/header.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.0.46
+// @version      1.0.47
 // @description  Adds a prompt suggestion dropdown inside the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest

--- a/src/helpers/options.ts
+++ b/src/helpers/options.ts
@@ -9,7 +9,7 @@ export interface Options {
   hideLogoText: boolean;
   hideLogoImage: boolean;
   hideProfile: boolean;
-  hideEnvironments: boolean;
+  hideSettings: boolean;
   threeColumnMode: boolean;
   autoCheckUpdates: boolean;
   showRepoSidebar: boolean;
@@ -40,7 +40,7 @@ export const DEFAULT_OPTIONS: Options = {
   hideLogoText: false,
   hideLogoImage: false,
   hideProfile: false,
-  hideEnvironments: false,
+  hideSettings: false,
   threeColumnMode: false,
   autoCheckUpdates: false,
   showRepoSidebar: true,
@@ -74,7 +74,7 @@ const OPTION_VALIDATORS: { [K in keyof Options]: (v: unknown) => v is Options[K]
   hideLogoText: (v): v is Options['hideLogoText'] => typeof v === 'boolean',
   hideLogoImage: (v): v is Options['hideLogoImage'] => typeof v === 'boolean',
   hideProfile: (v): v is Options['hideProfile'] => typeof v === 'boolean',
-  hideEnvironments: (v): v is Options['hideEnvironments'] => typeof v === 'boolean',
+  hideSettings: (v): v is Options['hideSettings'] => typeof v === 'boolean',
   threeColumnMode: (v): v is Options['threeColumnMode'] => typeof v === 'boolean',
   autoCheckUpdates: (v): v is Options['autoCheckUpdates'] => typeof v === 'boolean',
   showRepoSidebar: (v): v is Options['showRepoSidebar'] => typeof v === 'boolean',
@@ -111,6 +111,10 @@ export function loadOptions(): Options {
   const raw = loadJSON<Record<string, unknown>>(STORAGE_KEY, {});
   if ('dark' in raw && !('theme' in raw)) {
     raw.theme = (raw as any).dark ? 'dark' : 'light';
+  }
+  if ('hideEnvironments' in raw && !('hideSettings' in raw)) {
+    (raw as any).hideSettings = (raw as any).hideEnvironments;
+    delete (raw as any).hideEnvironments;
   }
   const opts = sanitizeOptions(raw);
   return { ...DEFAULT_OPTIONS, ...opts };

--- a/src/index.ts
+++ b/src/index.ts
@@ -361,8 +361,8 @@ body, html {
         if (node) node.style.display = hide ? 'none' : '';
     }
 
-    function toggleEnvironments(hide) {
-        const link = document.querySelector('a[href="/codex/settings/environments"]');
+    function toggleSettingsButton(hide) {
+        const link = document.querySelector('a[href="/codex/settings"]');
         if (link) link.style.display = hide ? 'none' : '';
     }
 
@@ -497,7 +497,7 @@ body, html {
         toggleLogoText(options.hideLogoText);
         toggleLogoImage(options.hideLogoImage);
         toggleProfile(options.hideProfile);
-        toggleEnvironments(options.hideEnvironments);
+        toggleSettingsButton(options.hideSettings);
         toggleRepoSidebar(options.showRepoSidebar);
         toggleVersionSidebar(options.showVersionSidebar);
 
@@ -611,7 +611,7 @@ body, html {
         createCheckbox('gpt-setting-logo-text', 'Hide logo text'), document.createElement('br'),
         createCheckbox('gpt-setting-logo-image', 'Hide logo image'), document.createElement('br'),
         createCheckbox('gpt-setting-profile', 'Hide profile icon'), document.createElement('br'),
-        createCheckbox('gpt-setting-environments', 'Hide environments button'), document.createElement('br'),
+        createCheckbox('gpt-setting-settings-button', 'Hide Settings button'), document.createElement('br'),
         createCheckbox('gpt-setting-three-column', '3 column layout')
     ]);
     modalContent.appendChild(interfaceGroup);
@@ -1044,7 +1044,7 @@ body, html {
         modal.querySelector('#gpt-setting-logo-text').checked = options.hideLogoText;
         modal.querySelector('#gpt-setting-logo-image').checked = options.hideLogoImage;
         modal.querySelector('#gpt-setting-profile').checked = options.hideProfile;
-        modal.querySelector('#gpt-setting-environments').checked = options.hideEnvironments;
+        modal.querySelector('#gpt-setting-settings-button').checked = options.hideSettings;
         modal.querySelector('#gpt-setting-three-column').checked = options.threeColumnMode;
         modal.querySelector('#gpt-setting-auto-updates').checked = options.autoCheckUpdates;
         modal.querySelector('#gpt-setting-disable-history').checked = options.disableHistory;
@@ -1145,7 +1145,7 @@ body, html {
     modal.querySelector('#gpt-setting-logo-text').addEventListener('change', (e) => { options.hideLogoText = e.target.checked; saveOptions(options); applyOptions(); });
     modal.querySelector('#gpt-setting-logo-image').addEventListener('change', (e) => { options.hideLogoImage = e.target.checked; saveOptions(options); applyOptions(); });
     modal.querySelector('#gpt-setting-profile').addEventListener('change', (e) => { options.hideProfile = e.target.checked; saveOptions(options); applyOptions(); });
-    modal.querySelector('#gpt-setting-environments').addEventListener('change', (e) => { options.hideEnvironments = e.target.checked; saveOptions(options); applyOptions(); });
+    modal.querySelector('#gpt-setting-settings-button').addEventListener('change', (e) => { options.hideSettings = e.target.checked; saveOptions(options); applyOptions(); });
     modal.querySelector('#gpt-setting-three-column').addEventListener('change', (e) => { options.threeColumnMode = e.target.checked; saveOptions(options); applyOptions(); });
     modal.querySelector('#gpt-setting-auto-updates').addEventListener('change', (e) => { options.autoCheckUpdates = e.target.checked; saveOptions(options); });
     modal.querySelector('#gpt-setting-disable-history').addEventListener('change', (e) => { options.disableHistory = e.target.checked; saveOptions(options); });
@@ -1177,7 +1177,7 @@ body, html {
         toggleLogoText(options.hideLogoText);
         toggleLogoImage(options.hideLogoImage);
         toggleProfile(options.hideProfile);
-        toggleEnvironments(options.hideEnvironments);
+        toggleSettingsButton(options.hideSettings);
         toggleRepoSidebar(options.showRepoSidebar);
         toggleVersionSidebar(options.showVersionSidebar);
     });

--- a/tests/options.test.ts
+++ b/tests/options.test.ts
@@ -29,3 +29,17 @@ test('loadOptions discards invalid and unknown values', { concurrency: false }, 
   assert.strictEqual(opts.historyLimit, DEFAULT_OPTIONS.historyLimit);
   assert.ok(!('foo' in opts));
 });
+
+test('loadOptions migrates hideEnvironments to hideSettings', { concurrency: false }, () => {
+  const dom = new JSDOM('', { url: 'https://example.com' });
+  (globalThis as any).localStorage = dom.window.localStorage;
+
+  dom.window.localStorage.setItem(
+    STORAGE_KEY,
+    JSON.stringify({ hideEnvironments: true })
+  );
+
+  const opts = loadOptions();
+  assert.strictEqual((opts as any).hideEnvironments, undefined);
+  assert.strictEqual(opts.hideSettings, true);
+});


### PR DESCRIPTION
## Summary
- hide the new "Settings" button instead of the old "Environments" button
- rename `hideEnvironments` option to `hideSettings` and migrate old saved options
- document the change and bump script version

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68aec746951c83259a888e10079df50e