### PR TITLE
fix: locate settings button via general settings link

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -278,7 +278,7 @@
   var VERSION;
   var init_version = __esm({
     "src/version.ts"() {
-      VERSION = "1.0.47";
+      VERSION = "1.0.48";
     }
   });
 
@@ -626,7 +626,7 @@ body, html {
           if (node) node.style.display = hide ? "none" : "";
         }
         function toggleSettingsButton(hide) {
-          const link = document.querySelector('a[href="/codex/settings"]');
+          const link = Array.from(document.querySelectorAll('a[href="/codex/settings/general"]')).filter((el) => el.textContent.trim() === "Settings")[0];
           if (link) link.style.display = hide ? "none" : "";
         }
         function makeSidebarInteractive(el, prefix) {

--- a/openai-codex.user.js
+++ b/openai-codex.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.0.47
+// @version      1.0.48
 // @description  Adds a prompt suggestion dropdown inside the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest
@@ -287,7 +287,7 @@
   var VERSION;
   var init_version = __esm({
     "src/version.ts"() {
-      VERSION = "1.0.47";
+      VERSION = "1.0.48";
     }
   });
 
@@ -635,7 +635,7 @@ body, html {
           if (node) node.style.display = hide ? "none" : "";
         }
         function toggleSettingsButton(hide) {
-          const link = document.querySelector('a[href="/codex/settings"]');
+          const link = Array.from(document.querySelectorAll('a[href="/codex/settings/general"]')).filter((el) => el.textContent.trim() === "Settings")[0];
           if (link) link.style.display = hide ? "none" : "";
         }
         function makeSidebarInteractive(el, prefix) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.47",
+  "version": "1.0.48",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openai-codex-userscript",
-      "version": "1.0.47",
+      "version": "1.0.48",
       "license": "ISC",
       "devDependencies": {
         "esbuild": "^0.25.6",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.47",
+  "version": "1.0.48",
   "scripts": {
     "build": "node build.js",
     "test": "npm run build && node --test -r ts-node/register tests/*.test.ts"

--- a/src/header.js
+++ b/src/header.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.0.47
+// @version      1.0.48
 // @description  Adds a prompt suggestion dropdown inside the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest

--- a/src/index.ts
+++ b/src/index.ts
@@ -362,7 +362,7 @@ body, html {
     }
 
     function toggleSettingsButton(hide) {
-        const link = document.querySelector('a[href="/codex/settings"]');
+        const link = Array.from(document.querySelectorAll('a[href="/codex/settings/general"]')).filter(el => el.textContent.trim() === "Settings")[0];
         if (link) link.style.display = hide ? 'none' : '';
     }
 


### PR DESCRIPTION
## Summary
- refine settings button lookup to filter anchors for `/codex/settings/general` with "Settings" text
- bump version to 1.0.48

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c17ea4786c8325994d5a3191fb35c7