### PR TITLE
Add live task statistics modal

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -274,11 +274,37 @@
     }
   });
 
+  // src/helpers/stats.ts
+  function getTaskStats() {
+    const rows = Array.from(document.querySelectorAll(".task-row-container"));
+    const open = rows.filter((row) => {
+      var _a;
+      return ((_a = row.querySelector("button")) == null ? void 0 : _a.textContent.trim()) === "Open";
+    }).length;
+    const merged = rows.filter((row) => {
+      var _a;
+      return ((_a = row.querySelector("button")) == null ? void 0 : _a.textContent.trim()) === "Merged";
+    }).length;
+    const closed = rows.filter((row) => {
+      var _a;
+      return ((_a = row.querySelector("button")) == null ? void 0 : _a.textContent.trim()) === "Closed";
+    }).length;
+    const inProgress = rows.filter((row) => row.querySelector("circle")).length;
+    const fourX = rows.filter(
+      (container) => Array.from(container.querySelectorAll("span")).some((span) => span.textContent.trim() === "4")
+    ).length;
+    return { open, merged, closed, inProgress, fourX };
+  }
+  var init_stats = __esm({
+    "src/helpers/stats.ts"() {
+    }
+  });
+
   // src/version.ts
   var VERSION;
   var init_version = __esm({
     "src/version.ts"() {
-      VERSION = "1.0.47";
+      VERSION = "1.0.48";
     }
   });
 
@@ -289,6 +315,7 @@
       init_suggestions();
       init_history();
       init_repos();
+      init_stats();
       init_version();
       (function() {
         "use strict";
@@ -532,6 +559,10 @@
 #gpt-history-preview.show { display: flex; }
 #gpt-history-preview .modal-content { background: var(--background); color: var(--foreground); border: 1px solid var(--ring); border-radius: 0.5rem; padding: 1rem; max-width: 90%; width: 400px; max-height: 80vh; overflow-y: auto; }
 #gpt-history-preview button { border: 1px solid var(--ring); padding: 2px 6px; border-radius: 4px; }
+#gpt-stats-modal { position: fixed; inset: 0; z-index: 1000; background: rgba(0,0,0,0.5); display: none; align-items: center; justify-content: center; }
+#gpt-stats-modal.show { display: flex; }
+#gpt-stats-modal .modal-content { background: var(--background); color: var(--foreground); border: 1px solid var(--ring); border-radius: 0.5rem; padding: 1rem; max-width: 90%; width: 300px; }
+#gpt-stats-modal button { border: 1px solid var(--ring); padding: 2px 6px; border-radius: 4px; }
 #gpt-repo-sidebar, #gpt-version-sidebar { position: fixed; inset-block-start: 10%; max-height: 80vh; width: 180px; background: var(--background); color: var(--foreground); border: 1px solid var(--ring); overflow-y: auto; z-index: 999; padding: 0.5rem; border-radius: 0.25rem; box-shadow: 0 2px 6px rgba(0,0,0,0.2); resize: both; }
 #gpt-repo-sidebar { inset-inline-start: 10px; }
 #gpt-version-sidebar { inset-inline-end: 10px; }
@@ -829,6 +860,8 @@ body, html {
         actionBar.appendChild(repoBtn);
         const versionBtn = createActionBtn("gpt-version-btn", "\u{1F516}", "Versions");
         actionBar.appendChild(versionBtn);
+        const statsBtn = createActionBtn("gpt-stats-btn", "\u{1F4CA}", "Stats");
+        actionBar.appendChild(statsBtn);
         const settingsBtn = createActionBtn("gpt-settings-btn", "\u2699\uFE0F", "Settings");
         actionBar.appendChild(settingsBtn);
         const modal = document.createElement("div");
@@ -945,6 +978,48 @@ body, html {
         histContent.appendChild(histActions);
         historyModal.appendChild(histContent);
         document.body.appendChild(historyModal);
+        const statsModal = document.createElement("div");
+        statsModal.id = "gpt-stats-modal";
+        const statsContent = document.createElement("div");
+        statsContent.className = "modal-content";
+        const statsTitle = document.createElement("h2");
+        statsTitle.className = "mb-2 text-lg";
+        statsTitle.textContent = "Current Stats";
+        statsContent.appendChild(statsTitle);
+        const statsList = document.createElement("ul");
+        statsList.id = "gpt-stats-list";
+        statsContent.appendChild(statsList);
+        const statsActions = document.createElement("div");
+        statsActions.className = "mt-2 text-right";
+        statsActions.appendChild(createButton("Close", "btn btn-secondary btn-small", "gpt-stats-close"));
+        statsContent.appendChild(statsActions);
+        statsModal.appendChild(statsContent);
+        document.body.appendChild(statsModal);
+        function renderStats() {
+          const list = statsModal.querySelector("#gpt-stats-list");
+          if (!list) return;
+          const { open, merged, closed, inProgress, fourX } = getTaskStats();
+          list.innerHTML = `
+            <li>Open PRs: ${open}</li>
+            <li>Merged PRs: ${merged}</li>
+            <li>Closed PRs: ${closed}</li>
+            <li>Being Worked On: ${inProgress}</li>
+            <li>4x Run Tasks: ${fourX}</li>
+        `;
+        }
+        statsBtn.addEventListener("click", () => {
+          renderStats();
+          statsModal.classList.add("show");
+        });
+        statsModal.querySelector("#gpt-stats-close").addEventListener("click", () => statsModal.classList.remove("show"));
+        statsModal.addEventListener("click", (e) => {
+          if (e.target === statsModal) statsModal.classList.remove("show");
+        });
+        const statsObserver = new MutationObserver(() => {
+          if (statsModal.classList.contains("show")) renderStats();
+        });
+        observers.push(statsObserver);
+        statsObserver.observe(document.body, { childList: true, subtree: true, characterData: true });
         const historyPreview = document.createElement("div");
         historyPreview.id = "gpt-history-preview";
         const previewContent = document.createElement("div");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.47",
+  "version": "1.0.48",
   "scripts": {
     "build": "node build.js",
     "test": "npm run build && node --test -r ts-node/register tests/*.test.ts"

--- a/src/header.js
+++ b/src/header.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.0.47
+// @version      1.0.48
 // @description  Adds a prompt suggestion dropdown inside the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest

--- a/src/helpers/stats.ts
+++ b/src/helpers/stats.ts
@@ -1,0 +1,19 @@
+export interface TaskStats {
+  open: number;
+  merged: number;
+  closed: number;
+  inProgress: number;
+  fourX: number;
+}
+
+export function getTaskStats(): TaskStats {
+  const rows = Array.from(document.querySelectorAll('.task-row-container')) as HTMLElement[];
+  const open = rows.filter(row => row.querySelector('button')?.textContent.trim() === 'Open').length;
+  const merged = rows.filter(row => row.querySelector('button')?.textContent.trim() === 'Merged').length;
+  const closed = rows.filter(row => row.querySelector('button')?.textContent.trim() === 'Closed').length;
+  const inProgress = rows.filter(row => row.querySelector('circle')).length;
+  const fourX = rows.filter(container =>
+    Array.from(container.querySelectorAll('span')).some(span => span.textContent.trim() === '4')
+  ).length;
+  return { open, merged, closed, inProgress, fourX };
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { loadSuggestions, saveSuggestions, DEFAULT_SUGGESTIONS } from "./helpers
 import { loadHistory, saveHistory, addToHistory } from "./helpers/history";
 import { findPromptInput, setPromptText } from "./helpers/dom";
 import { parseRepoNames } from "./helpers/repos";
+import { getTaskStats } from "./helpers/stats";
 import { VERSION } from "./version";
 (function () {
 
@@ -257,6 +258,10 @@ import { VERSION } from "./version";
 #gpt-history-preview.show { display: flex; }
 #gpt-history-preview .modal-content { background: var(--background); color: var(--foreground); border: 1px solid var(--ring); border-radius: 0.5rem; padding: 1rem; max-width: 90%; width: 400px; max-height: 80vh; overflow-y: auto; }
 #gpt-history-preview button { border: 1px solid var(--ring); padding: 2px 6px; border-radius: 4px; }
+#gpt-stats-modal { position: fixed; inset: 0; z-index: 1000; background: rgba(0,0,0,0.5); display: none; align-items: center; justify-content: center; }
+#gpt-stats-modal.show { display: flex; }
+#gpt-stats-modal .modal-content { background: var(--background); color: var(--foreground); border: 1px solid var(--ring); border-radius: 0.5rem; padding: 1rem; max-width: 90%; width: 300px; }
+#gpt-stats-modal button { border: 1px solid var(--ring); padding: 2px 6px; border-radius: 4px; }
 #gpt-repo-sidebar, #gpt-version-sidebar { position: fixed; inset-block-start: 10%; max-height: 80vh; width: 180px; background: var(--background); color: var(--foreground); border: 1px solid var(--ring); overflow-y: auto; z-index: 999; padding: 0.5rem; border-radius: 0.25rem; box-shadow: 0 2px 6px rgba(0,0,0,0.2); resize: both; }
 #gpt-repo-sidebar { inset-inline-start: 10px; }
 #gpt-version-sidebar { inset-inline-end: 10px; }
@@ -574,6 +579,9 @@ body, html {
     const versionBtn = createActionBtn('gpt-version-btn', '🔖', 'Versions');
     actionBar.appendChild(versionBtn);
 
+    const statsBtn = createActionBtn('gpt-stats-btn', '📊', 'Stats');
+    actionBar.appendChild(statsBtn);
+
     const settingsBtn = createActionBtn('gpt-settings-btn', '⚙️', 'Settings');
     actionBar.appendChild(settingsBtn);
 
@@ -679,6 +687,51 @@ body, html {
     histContent.appendChild(histActions);
     historyModal.appendChild(histContent);
     document.body.appendChild(historyModal);
+
+    const statsModal = document.createElement('div');
+    statsModal.id = 'gpt-stats-modal';
+    const statsContent = document.createElement('div');
+    statsContent.className = 'modal-content';
+    const statsTitle = document.createElement('h2');
+    statsTitle.className = 'mb-2 text-lg';
+    statsTitle.textContent = 'Current Stats';
+    statsContent.appendChild(statsTitle);
+    const statsList = document.createElement('ul');
+    statsList.id = 'gpt-stats-list';
+    statsContent.appendChild(statsList);
+    const statsActions = document.createElement('div');
+    statsActions.className = 'mt-2 text-right';
+    statsActions.appendChild(createButton('Close', 'btn btn-secondary btn-small', 'gpt-stats-close'));
+    statsContent.appendChild(statsActions);
+    statsModal.appendChild(statsContent);
+    document.body.appendChild(statsModal);
+
+    function renderStats() {
+        const list = statsModal.querySelector('#gpt-stats-list');
+        if (!list) return;
+        const { open, merged, closed, inProgress, fourX } = getTaskStats();
+        list.innerHTML = `
+            <li>Open PRs: ${open}</li>
+            <li>Merged PRs: ${merged}</li>
+            <li>Closed PRs: ${closed}</li>
+            <li>Being Worked On: ${inProgress}</li>
+            <li>4x Run Tasks: ${fourX}</li>
+        `;
+    }
+
+    statsBtn.addEventListener('click', () => {
+        renderStats();
+        statsModal.classList.add('show');
+    });
+
+    statsModal.querySelector('#gpt-stats-close').addEventListener('click', () => statsModal.classList.remove('show'));
+    statsModal.addEventListener('click', (e) => { if (e.target === statsModal) statsModal.classList.remove('show'); });
+
+    const statsObserver = new MutationObserver(() => {
+        if (statsModal.classList.contains('show')) renderStats();
+    });
+    observers.push(statsObserver);
+    statsObserver.observe(document.body, { childList: true, subtree: true, characterData: true });
 
     const historyPreview = document.createElement('div');
     historyPreview.id = 'gpt-history-preview';

--- a/tests/stats.test.ts
+++ b/tests/stats.test.ts
@@ -1,0 +1,18 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import { JSDOM } from 'jsdom';
+import { getTaskStats } from '../src/helpers/stats';
+
+test('computes task stats correctly', { concurrency: false }, () => {
+  const html = `
+    <div class="task-row-container"><button>Open</button></div>
+    <div class="task-row-container"><button>Merged</button></div>
+    <div class="task-row-container"><button>Closed</button></div>
+    <div class="task-row-container"><circle></circle></div>
+    <div class="task-row-container"><span>4</span></div>
+  `;
+  const dom = new JSDOM(html);
+  (globalThis as any).document = dom.window.document;
+  const stats = getTaskStats();
+  assert.deepStrictEqual(stats, { open: 1, merged: 1, closed: 1, inProgress: 1, fourX: 1 });
+});


### PR DESCRIPTION
## Summary
- add reusable `getTaskStats` helper
- add Stats button and modal to display open, merged, closed, in-progress and 4× run counts
- update build artifacts and bump version to 1.0.48

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c18086d5cc832597ce84b8e893cef3