### PR TITLE
Add live task statistics modal

### DIFF
--- a/dist/index.js
+++ b/dist/index.js
@@ -304,7 +304,7 @@
   var VERSION;
   var init_version = __esm({
     "src/version.ts"() {
-      VERSION = "1.0.48";
+      VERSION = "1.0.49";
     }
   });
 
@@ -1007,19 +1007,35 @@ body, html {
             <li>4x Run Tasks: ${fourX}</li>
         `;
         }
-        statsBtn.addEventListener("click", () => {
-          renderStats();
-          statsModal.classList.add("show");
-        });
-        statsModal.querySelector("#gpt-stats-close").addEventListener("click", () => statsModal.classList.remove("show"));
-        statsModal.addEventListener("click", (e) => {
-          if (e.target === statsModal) statsModal.classList.remove("show");
-        });
+        const observerConfig = { childList: true, subtree: true, characterData: true };
+        const getStatsTarget = () => {
+          var _a;
+          return ((_a = document.querySelector(".task-row-container")) == null ? void 0 : _a.parentElement) || document.body;
+        };
         const statsObserver = new MutationObserver(() => {
-          if (statsModal.classList.contains("show")) renderStats();
+          if (statsModal.classList.contains("show")) {
+            statsObserver.disconnect();
+            renderStats();
+            statsObserver.observe(getStatsTarget(), observerConfig);
+          }
         });
         observers.push(statsObserver);
-        statsObserver.observe(document.body, { childList: true, subtree: true, characterData: true });
+        statsBtn.addEventListener("click", () => {
+          statsObserver.disconnect();
+          renderStats();
+          statsModal.classList.add("show");
+          statsObserver.observe(getStatsTarget(), observerConfig);
+        });
+        statsModal.querySelector("#gpt-stats-close").addEventListener("click", () => {
+          statsModal.classList.remove("show");
+          statsObserver.disconnect();
+        });
+        statsModal.addEventListener("click", (e) => {
+          if (e.target === statsModal) {
+            statsModal.classList.remove("show");
+            statsObserver.disconnect();
+          }
+        });
         const historyPreview = document.createElement("div");
         historyPreview.id = "gpt-history-preview";
         const previewContent = document.createElement("div");

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.48",
+  "version": "1.0.49",
   "scripts": {
     "build": "node build.js",
     "test": "npm run build && node --test -r ts-node/register tests/*.test.ts"

--- a/src/header.js
+++ b/src/header.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.0.48
+// @version      1.0.49
 // @description  Adds a prompt suggestion dropdown inside the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest


### PR DESCRIPTION
## Summary
- prevent stats MutationObserver from re-rendering in a loop
- bump version to 1.0.49

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c19bcd13648325935bd0848c0aa134