### PR TITLE
feat: add daily update check and floating stats

### DIFF
--- a/openai-codex.user.js
+++ b/openai-codex.user.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.0.49
+// @version      1.0.50
 // @description  Adds a prompt suggestion dropdown inside the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest
@@ -135,6 +135,7 @@
         autoCheckUpdates: false,
         showRepoSidebar: true,
         showVersionSidebar: true,
+        showStatsWindow: false,
         clearClosedBranches: false,
         clearMergedBranches: false,
         clearOpenBranches: false,
@@ -149,7 +150,11 @@
         versionSidebarX: null,
         versionSidebarY: null,
         versionSidebarWidth: null,
-        versionSidebarHeight: null
+        versionSidebarHeight: null,
+        statsWindowX: null,
+        statsWindowY: null,
+        statsWindowWidth: null,
+        statsWindowHeight: null
       };
       STORAGE_KEY = "gpt-script-options";
       OPTION_VALIDATORS = {
@@ -166,6 +171,7 @@
         autoCheckUpdates: (v) => typeof v === "boolean",
         showRepoSidebar: (v) => typeof v === "boolean",
         showVersionSidebar: (v) => typeof v === "boolean",
+        showStatsWindow: (v) => typeof v === "boolean",
         clearClosedBranches: (v) => typeof v === "boolean",
         clearMergedBranches: (v) => typeof v === "boolean",
         clearOpenBranches: (v) => typeof v === "boolean",
@@ -180,7 +186,11 @@
         versionSidebarX: (v) => typeof v === "number" && Number.isFinite(v) || v === null,
         versionSidebarY: (v) => typeof v === "number" && Number.isFinite(v) || v === null,
         versionSidebarWidth: (v) => typeof v === "number" && Number.isFinite(v) || v === null,
-        versionSidebarHeight: (v) => typeof v === "number" && Number.isFinite(v) || v === null
+        versionSidebarHeight: (v) => typeof v === "number" && Number.isFinite(v) || v === null,
+        statsWindowX: (v) => typeof v === "number" && Number.isFinite(v) || v === null,
+        statsWindowY: (v) => typeof v === "number" && Number.isFinite(v) || v === null,
+        statsWindowWidth: (v) => typeof v === "number" && Number.isFinite(v) || v === null,
+        statsWindowHeight: (v) => typeof v === "number" && Number.isFinite(v) || v === null
       };
     }
   });
@@ -298,7 +308,9 @@
       var _a;
       return ((_a = row.querySelector("button")) == null ? void 0 : _a.textContent.trim()) === "Closed";
     }).length;
-    const inProgress = rows.filter((row) => row.querySelector("circle")).length;
+    const inProgress = rows.filter(
+      (row) => row.querySelector("circle") || row.querySelector('[aria-label*="Cancel task"]')
+    ).length;
     const fourX = rows.filter(
       (container) => Array.from(container.querySelectorAll("span")).some((span) => span.textContent.trim() === "4")
     ).length;
@@ -313,7 +325,7 @@
   var VERSION;
   var init_version = __esm({
     "src/version.ts"() {
-      VERSION = "1.0.49";
+      VERSION = "1.0.50";
     }
   });
 
@@ -326,6 +338,7 @@
       init_repos();
       init_stats();
       init_version();
+      init_storage();
       (function() {
         "use strict";
         const SCRIPT_VERSION = VERSION;
@@ -334,6 +347,8 @@
         let dropdownObserver = null;
         let currentPromptDiv = null;
         let currentColDiv = null;
+        const LAST_UPDATE_CHECK_KEY = "gpt-last-update-check";
+        let toastContainer = null;
         function createButton(text, className = "btn relative btn-secondary btn-small", id) {
           const btn = document.createElement("button");
           btn.className = className;
@@ -377,6 +392,21 @@
           group.appendChild(h3);
           children.forEach((c) => group.appendChild(c));
           return group;
+        }
+        function showToast(message, onClick) {
+          const toast = document.createElement("div");
+          toast.className = "gpt-toast";
+          toast.textContent = message;
+          if (onClick) {
+            toast.addEventListener("click", () => {
+              onClick();
+              toast.remove();
+            });
+          } else {
+            toast.addEventListener("click", () => toast.remove());
+          }
+          toastContainer.appendChild(toast);
+          setTimeout(() => toast.remove(), 1e4);
         }
         const THEME_TOKENS = {
           light: {
@@ -568,15 +598,14 @@
 #gpt-history-preview.show { display: flex; }
 #gpt-history-preview .modal-content { background: var(--background); color: var(--foreground); border: 1px solid var(--ring); border-radius: 0.5rem; padding: 1rem; max-width: 90%; width: 400px; max-height: 80vh; overflow-y: auto; }
 #gpt-history-preview button { border: 1px solid var(--ring); padding: 2px 6px; border-radius: 4px; }
-#gpt-stats-modal { position: fixed; inset: 0; z-index: 1000; background: rgba(0,0,0,0.5); display: none; align-items: center; justify-content: center; }
-#gpt-stats-modal.show { display: flex; }
-#gpt-stats-modal .modal-content { background: var(--background); color: var(--foreground); border: 1px solid var(--ring); border-radius: 0.5rem; padding: 1rem; max-width: 90%; width: 300px; }
-#gpt-stats-modal button { border: 1px solid var(--ring); padding: 2px 6px; border-radius: 4px; }
-#gpt-repo-sidebar, #gpt-version-sidebar { position: fixed; inset-block-start: 10%; max-height: 80vh; width: 180px; background: var(--background); color: var(--foreground); border: 1px solid var(--ring); overflow-y: auto; z-index: 999; padding: 0.5rem; border-radius: 0.25rem; box-shadow: 0 2px 6px rgba(0,0,0,0.2); resize: both; }
+#gpt-repo-sidebar, #gpt-version-sidebar, #gpt-stats-window { position: fixed; inset-block-start: 10%; max-height: 80vh; width: 180px; background: var(--background); color: var(--foreground); border: 1px solid var(--ring); overflow-y: auto; z-index: 999; padding: 0.5rem; border-radius: 0.25rem; box-shadow: 0 2px 6px rgba(0,0,0,0.2); resize: both; }
 #gpt-repo-sidebar { inset-inline-start: 10px; }
 #gpt-version-sidebar { inset-inline-end: 10px; }
-#gpt-repo-sidebar.hidden, #gpt-version-sidebar.hidden { display: none; }
-#gpt-repo-sidebar > div:first-child, #gpt-version-sidebar > div:first-child { cursor: move; }
+#gpt-stats-window { inset-inline-start: 10px; }
+#gpt-repo-sidebar.hidden, #gpt-version-sidebar.hidden, #gpt-stats-window.hidden { display: none; }
+#gpt-repo-sidebar > div:first-child, #gpt-version-sidebar > div:first-child, #gpt-stats-window > div:first-child { cursor: move; }
+#gpt-toast-container { position: fixed; left: 16px; bottom: 16px; z-index: 1000; display: flex; flex-direction: column; gap: 8px; }
+.gpt-toast { background: var(--background); color: var(--foreground); border: 1px solid var(--ring); padding: 0.5rem 1rem; border-radius: 0.25rem; box-shadow: 0 2px 6px rgba(0,0,0,0.2); cursor: pointer; }
 `;
         document.head.appendChild(settingsStyle);
         const fallbackStyle = document.createElement("style");
@@ -803,6 +832,7 @@ body, html {
           toggleSettingsButton(options.hideSettings);
           toggleRepoSidebar(options.showRepoSidebar);
           toggleVersionSidebar(options.showVersionSidebar);
+          toggleStatsWindow(options.showStatsWindow);
           if (options.threeColumnMode) {
             if (!document.head.contains(columnStyle)) document.head.appendChild(columnStyle);
           } else {
@@ -824,8 +854,16 @@ body, html {
             if (options.versionSidebarHeight !== null) verEl.style.height = options.versionSidebarHeight + "px";
             ensureSidebarInBounds(verEl, "versionSidebar");
           }
+          const statsEl = document.getElementById("gpt-stats-window");
+          if (statsEl) {
+            if (options.statsWindowX !== null) statsEl.style.left = options.statsWindowX + "px";
+            if (options.statsWindowY !== null) statsEl.style.top = options.statsWindowY + "px";
+            if (options.statsWindowWidth !== null) statsEl.style.width = options.statsWindowWidth + "px";
+            if (options.statsWindowHeight !== null) statsEl.style.height = options.statsWindowHeight + "px";
+            ensureSidebarInBounds(statsEl, "statsWindow");
+          }
         }
-        async function checkForUpdates() {
+        async function checkForUpdates(manual = false) {
           const url = "https://raw.githubusercontent.com/supermarsx/openai-codex-userscript/main/openai-codex.user.js";
           try {
             const txt = await new Promise((resolve, reject) => {
@@ -849,13 +887,14 @@ body, html {
             if (m) {
               const latest = m[1];
               if (latest !== SCRIPT_VERSION) {
-                if (window.confirm(`Update available (v${latest}). Open download page?`)) {
+                showToast(`Update available (v${latest}). Click to download.`, () => {
                   window.open("https://github.com/supermarsx/openai-codex-userscript/raw/refs/heads/main/openai-codex.user.js", "_blank");
-                }
-              } else {
-                window.alert("No updates found.");
+                });
+              } else if (manual) {
+                showToast("No updates found.");
               }
             }
+            saveJSON(LAST_UPDATE_CHECK_KEY, Date.now());
           } catch (e) {
             console.error("Failed to check for updates", e);
           }
@@ -863,6 +902,9 @@ body, html {
         const actionBar = document.createElement("div");
         actionBar.id = "gpt-action-bar";
         document.body.appendChild(actionBar);
+        toastContainer = document.createElement("div");
+        toastContainer.id = "gpt-toast-container";
+        document.body.appendChild(toastContainer);
         const historyBtn = createActionBtn("gpt-history-btn", "\u{1F4DC}", "History");
         actionBar.appendChild(historyBtn);
         const repoBtn = createActionBtn("gpt-repo-btn", "\u{1F4C1}", "Repos");
@@ -936,7 +978,7 @@ body, html {
         ]);
         modalContent.appendChild(branchesGroup);
         const otherGroup = createSettingGroup("Other", [
-          createCheckbox("gpt-setting-auto-updates", "Auto-check for updates"),
+          createCheckbox("gpt-setting-auto-updates", "Check for updates daily"),
           document.createElement("br"),
           createCheckbox("gpt-setting-disable-history", "Disable prompt history"),
           document.createElement("br"),
@@ -987,25 +1029,23 @@ body, html {
         histContent.appendChild(histActions);
         historyModal.appendChild(histContent);
         document.body.appendChild(historyModal);
-        const statsModal = document.createElement("div");
-        statsModal.id = "gpt-stats-modal";
-        const statsContent = document.createElement("div");
-        statsContent.className = "modal-content";
-        const statsTitle = document.createElement("h2");
-        statsTitle.className = "mb-2 text-lg";
+        const statsWindow = document.createElement("div");
+        statsWindow.id = "gpt-stats-window";
+        const statsHeader = document.createElement("div");
+        statsHeader.className = "flex justify-between items-center";
+        const statsTitle = document.createElement("h3");
+        statsTitle.className = "m-0";
         statsTitle.textContent = "Current Stats";
-        statsContent.appendChild(statsTitle);
+        statsHeader.appendChild(statsTitle);
+        statsHeader.appendChild(createButton("\xD7", "btn relative btn-secondary btn-small", "gpt-stats-hide"));
+        statsWindow.appendChild(statsHeader);
         const statsList = document.createElement("ul");
         statsList.id = "gpt-stats-list";
-        statsContent.appendChild(statsList);
-        const statsActions = document.createElement("div");
-        statsActions.className = "mt-2 text-right";
-        statsActions.appendChild(createButton("Close", "btn btn-secondary btn-small", "gpt-stats-close"));
-        statsContent.appendChild(statsActions);
-        statsModal.appendChild(statsContent);
-        document.body.appendChild(statsModal);
+        statsWindow.appendChild(statsList);
+        document.body.appendChild(statsWindow);
+        makeSidebarInteractive(statsWindow, "statsWindow");
         function renderStats() {
-          const list = statsModal.querySelector("#gpt-stats-list");
+          const list = statsWindow.querySelector("#gpt-stats-list");
           if (!list) return;
           const { open, merged, closed, inProgress, fourX } = getTaskStats();
           list.innerHTML = `
@@ -1022,28 +1062,30 @@ body, html {
           return ((_a = document.querySelector(".task-row-container")) == null ? void 0 : _a.parentElement) || document.body;
         };
         const statsObserver = new MutationObserver(() => {
-          if (statsModal.classList.contains("show")) {
-            statsObserver.disconnect();
+          if (!statsWindow.classList.contains("hidden")) {
             renderStats();
-            statsObserver.observe(getStatsTarget(), observerConfig);
           }
         });
         observers.push(statsObserver);
-        statsBtn.addEventListener("click", () => {
-          statsObserver.disconnect();
-          renderStats();
-          statsModal.classList.add("show");
-          statsObserver.observe(getStatsTarget(), observerConfig);
-        });
-        statsModal.querySelector("#gpt-stats-close").addEventListener("click", () => {
-          statsModal.classList.remove("show");
-          statsObserver.disconnect();
-        });
-        statsModal.addEventListener("click", (e) => {
-          if (e.target === statsModal) {
-            statsModal.classList.remove("show");
-            statsObserver.disconnect();
+        statsObserver.observe(getStatsTarget(), observerConfig);
+        function toggleStatsWindow(show) {
+          const el = statsWindow;
+          el.classList.toggle("hidden", !show);
+          if (show) {
+            renderStats();
+            ensureSidebarInBounds(el, "statsWindow");
           }
+        }
+        statsBtn.addEventListener("click", () => {
+          const show = statsWindow.classList.contains("hidden");
+          toggleStatsWindow(show);
+          options.showStatsWindow = show;
+          saveOptions(options);
+        });
+        statsWindow.querySelector("#gpt-stats-hide").addEventListener("click", () => {
+          toggleStatsWindow(false);
+          options.showStatsWindow = false;
+          saveOptions(options);
         });
         const historyPreview = document.createElement("div");
         historyPreview.id = "gpt-history-preview";
@@ -1577,7 +1619,7 @@ body, html {
           options.autoArchiveClosed = e.target.checked;
           saveOptions(options);
         });
-        modal.querySelector("#gpt-update-check").addEventListener("click", () => checkForUpdates());
+        modal.querySelector("#gpt-update-check").addEventListener("click", () => checkForUpdates(true));
         modal.querySelector("#gpt-reset-defaults").addEventListener("click", () => {
           options = __spreadValues({}, DEFAULT_OPTIONS);
           saveOptions(options);
@@ -1587,6 +1629,7 @@ body, html {
         modal.querySelector("#gpt-reset-windows").addEventListener("click", () => {
           options.repoSidebarX = options.repoSidebarY = options.repoSidebarWidth = options.repoSidebarHeight = null;
           options.versionSidebarX = options.versionSidebarY = options.versionSidebarWidth = options.versionSidebarHeight = null;
+          options.statsWindowX = options.statsWindowY = options.statsWindowWidth = options.statsWindowHeight = null;
           saveOptions(options);
           applyOptions();
         });
@@ -1604,7 +1647,10 @@ body, html {
         pageObserver.observe(document.body, { childList: true, subtree: true });
         applyOptions();
         if (options.autoCheckUpdates) {
-          checkForUpdates();
+          const last = loadJSON(LAST_UPDATE_CHECK_KEY, 0);
+          if (Date.now() - last > 864e5) {
+            checkForUpdates();
+          }
         }
         function findArchiveButton() {
           return document.querySelector('[data-testid="archive-task"]') || Array.from(document.querySelectorAll('button,[role="button"]')).find((b) => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.49",
+  "version": "1.0.50",
   "scripts": {
     "build": "node build.js",
     "test": "npm run build && node --test -r ts-node/register tests/*.test.ts"

--- a/src/header.js
+++ b/src/header.js
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex UI Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.0.49
+// @version      1.0.50
 // @description  Adds a prompt suggestion dropdown inside the input in ChatGPT Codex and provides a settings modal
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest

--- a/src/helpers/options.ts
+++ b/src/helpers/options.ts
@@ -14,6 +14,7 @@ export interface Options {
   autoCheckUpdates: boolean;
   showRepoSidebar: boolean;
   showVersionSidebar: boolean;
+  showStatsWindow: boolean;
   clearClosedBranches: boolean;
   clearMergedBranches: boolean;
   clearOpenBranches: boolean;
@@ -29,6 +30,10 @@ export interface Options {
   versionSidebarY: number | null;
   versionSidebarWidth: number | null;
   versionSidebarHeight: number | null;
+  statsWindowX: number | null;
+  statsWindowY: number | null;
+  statsWindowWidth: number | null;
+  statsWindowHeight: number | null;
 }
 
 export const DEFAULT_OPTIONS: Options = {
@@ -45,6 +50,7 @@ export const DEFAULT_OPTIONS: Options = {
   autoCheckUpdates: false,
   showRepoSidebar: true,
   showVersionSidebar: true,
+  showStatsWindow: false,
   clearClosedBranches: false,
   clearMergedBranches: false,
   clearOpenBranches: false,
@@ -60,6 +66,10 @@ export const DEFAULT_OPTIONS: Options = {
   versionSidebarY: null,
   versionSidebarWidth: null,
   versionSidebarHeight: null,
+  statsWindowX: null,
+  statsWindowY: null,
+  statsWindowWidth: null,
+  statsWindowHeight: null,
 };
 
 const STORAGE_KEY = 'gpt-script-options';
@@ -79,6 +89,7 @@ const OPTION_VALIDATORS: { [K in keyof Options]: (v: unknown) => v is Options[K]
   autoCheckUpdates: (v): v is Options['autoCheckUpdates'] => typeof v === 'boolean',
   showRepoSidebar: (v): v is Options['showRepoSidebar'] => typeof v === 'boolean',
   showVersionSidebar: (v): v is Options['showVersionSidebar'] => typeof v === 'boolean',
+  showStatsWindow: (v): v is Options['showStatsWindow'] => typeof v === 'boolean',
   clearClosedBranches: (v): v is Options['clearClosedBranches'] => typeof v === 'boolean',
   clearMergedBranches: (v): v is Options['clearMergedBranches'] => typeof v === 'boolean',
   clearOpenBranches: (v): v is Options['clearOpenBranches'] => typeof v === 'boolean',
@@ -94,6 +105,10 @@ const OPTION_VALIDATORS: { [K in keyof Options]: (v: unknown) => v is Options[K]
   versionSidebarY: (v): v is Options['versionSidebarY'] => (typeof v === 'number' && Number.isFinite(v)) || v === null,
   versionSidebarWidth: (v): v is Options['versionSidebarWidth'] => (typeof v === 'number' && Number.isFinite(v)) || v === null,
   versionSidebarHeight: (v): v is Options['versionSidebarHeight'] => (typeof v === 'number' && Number.isFinite(v)) || v === null,
+  statsWindowX: (v): v is Options['statsWindowX'] => (typeof v === 'number' && Number.isFinite(v)) || v === null,
+  statsWindowY: (v): v is Options['statsWindowY'] => (typeof v === 'number' && Number.isFinite(v)) || v === null,
+  statsWindowWidth: (v): v is Options['statsWindowWidth'] => (typeof v === 'number' && Number.isFinite(v)) || v === null,
+  statsWindowHeight: (v): v is Options['statsWindowHeight'] => (typeof v === 'number' && Number.isFinite(v)) || v === null,
 };
 
 function sanitizeOptions(raw: Record<string, unknown>): Partial<Options> {

--- a/src/helpers/stats.ts
+++ b/src/helpers/stats.ts
@@ -11,7 +11,10 @@ export function getTaskStats(): TaskStats {
   const open = rows.filter(row => row.querySelector('button')?.textContent.trim() === 'Open').length;
   const merged = rows.filter(row => row.querySelector('button')?.textContent.trim() === 'Merged').length;
   const closed = rows.filter(row => row.querySelector('button')?.textContent.trim() === 'Closed').length;
-  const inProgress = rows.filter(row => row.querySelector('circle')).length;
+  const inProgress = rows.filter(row =>
+    row.querySelector('circle') ||
+    row.querySelector('[aria-label*="Cancel task"]')
+  ).length;
   const fourX = rows.filter(container =>
     Array.from(container.querySelectorAll('span')).some(span => span.textContent.trim() === '4')
   ).length;

--- a/tests/stats.test.ts
+++ b/tests/stats.test.ts
@@ -9,10 +9,11 @@ test('computes task stats correctly', { concurrency: false }, () => {
     <div class="task-row-container"><button>Merged</button></div>
     <div class="task-row-container"><button>Closed</button></div>
     <div class="task-row-container"><circle></circle></div>
+    <div class="task-row-container"><button aria-label="Cancel task">Cancel</button></div>
     <div class="task-row-container"><span>4</span></div>
   `;
   const dom = new JSDOM(html);
   (globalThis as any).document = dom.window.document;
   const stats = getTaskStats();
-  assert.deepStrictEqual(stats, { open: 1, merged: 1, closed: 1, inProgress: 1, fourX: 1 });
+  assert.deepStrictEqual(stats, { open: 1, merged: 1, closed: 1, inProgress: 2, fourX: 1 });
 });


### PR DESCRIPTION
## Summary
- notify about new versions with a bottom-left toast and allow optional daily checks
- make task stats a draggable, resizable window
- count tasks with "Cancel task" buttons as currently being worked on

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1ae8204b08325ab73f88b44b24c92