### PR TITLE
fix: guard localStorage migration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.51",
+  "version": "1.0.53",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "openai-codex-userscript",
-      "version": "1.0.51",
+      "version": "1.0.53",
       "license": "ISC",
       "devDependencies": {
         "c8": "^9.1.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.52",
+  "version": "1.0.53",
   "scripts": {
     "build": "node build.js",
     "test": "npm run build && node --test -r ts-node/register tests/*.test.ts",

--- a/src/header.ts
+++ b/src/header.ts
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.0.52
+// @version      1.0.53
 // @description  Enhances user experience inside OpenAI Codex
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest

--- a/src/lib/storage.ts
+++ b/src/lib/storage.ts
@@ -33,16 +33,22 @@ export async function loadJSON<T>(key: string, fallback: T): Promise<T> {
             // fall through to fallback below
           }
         }
-        const lsValue =
-          typeof localStorage !== "undefined"
-            ? localStorage.getItem(key)
-            : null;
+        let lsValue: string | null = null;
+        if (typeof localStorage !== "undefined") {
+          try {
+            lsValue = localStorage.getItem(key);
+          } catch {
+            lsValue = null;
+          }
+        }
         if (lsValue !== null) {
           try {
             const parsed = JSON.parse(lsValue) as T;
             await saveJSON(key, parsed);
             if (typeof localStorage !== "undefined") {
-              localStorage.removeItem(key);
+              try {
+                localStorage.removeItem(key);
+              } catch {}
             }
             resolve(parsed);
           } catch {

--- a/tests/storage.test.ts
+++ b/tests/storage.test.ts
@@ -41,3 +41,14 @@ test("loadJSON migrates from localStorage", async () => {
   const second = await loadJSON("legacy", { c: 0 });
   assert.deepStrictEqual(second, { c: 3 });
 });
+
+test("loadJSON handles localStorage access errors", async () => {
+  const { loadJSON } = loadStorage();
+  const original = localStorage.getItem;
+  localStorage.getItem = () => {
+    throw new Error("denied");
+  };
+  const result = await loadJSON("blocked", { d: 4 });
+  assert.deepStrictEqual(result, { d: 4 });
+  localStorage.getItem = original;
+});


### PR DESCRIPTION
## Summary
- guard `localStorage` migration with try/catch to avoid hanging when storage is disabled
- add regression test for blocked `localStorage` access
- bump version to 1.0.53

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1dc92dba083259d02e83813059b54