### PR TITLE
Refactor stats sidebar and CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,7 +7,7 @@ on:
     branches: [main]
 
 jobs:
-  build:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -16,14 +16,50 @@ jobs:
           node-version: "20"
       - run: npm ci
       - run: npm run lint
+
+  format:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "20"
+      - run: npm ci
       - run: npm run format
+
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "20"
+      - run: npm ci
       - run: npm test
+
+  coverage:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "20"
+      - run: npm ci
       - run: npm run coverage
-      - run: npm run build
       - uses: actions/upload-artifact@v3
         with:
           name: coverage
           path: coverage
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: "20"
+      - run: npm ci
+      - run: npm run build
       - uses: actions/upload-artifact@v3
         with:
           name: userscript

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openai-codex-userscript",
-  "version": "1.0.54",
+  "version": "1.0.55",
   "scripts": {
     "build": "node build.js",
     "test": "npm run build && node --test -r ts-node/register tests/*.test.ts",

--- a/src/header.ts
+++ b/src/header.ts
@@ -1,7 +1,7 @@
 // ==UserScript==
 // @name         OpenAI Codex Enhancer
 // @namespace    http://tampermonkey.net/
-// @version      1.0.54
+// @version      1.0.55
 // @description  Enhances user experience inside OpenAI Codex
 // @match        https://chatgpt.com/codex*
 // @grant        GM_xmlhttpRequest

--- a/src/helpers/stats.ts
+++ b/src/helpers/stats.ts
@@ -4,8 +4,12 @@ export interface TaskStats {
   closed: number;
   inProgress: number;
   fourX: number;
+  total: number;
 }
 
+/**
+ * Collects task statistics from the DOM.
+ */
 export function getTaskStats(): TaskStats {
   const rows = Array.from(
     document.querySelectorAll(".task-row-container"),
@@ -29,5 +33,22 @@ export function getTaskStats(): TaskStats {
       (span) => span.textContent.trim() === "4",
     ),
   ).length;
-  return { open, merged, closed, inProgress, fourX };
+  const total = rows.length;
+  return { open, merged, closed, inProgress, fourX, total };
+}
+
+/**
+ * Renders task statistics into a list element.
+ */
+export function renderStats(list: HTMLElement): void {
+  const { open, merged, closed, inProgress, fourX, total } = getTaskStats();
+  list.innerHTML = `
+            <li>Total Tasks: ${total}</li>
+            <li>Open PRs: ${open}</li>
+            <li>Merged PRs: ${merged}</li>
+            <li>Closed PRs: ${closed}</li>
+            <li>Being Worked On: ${inProgress}</li>
+            <li>4x Run Tasks: ${fourX}</li>
+            <li id="gpt-stats-updated">Last updated: ${new Date().toLocaleString()}</li>
+        `;
 }

--- a/src/helpers/ui.ts
+++ b/src/helpers/ui.ts
@@ -1,0 +1,178 @@
+/**
+ * Creates a button element with optional class and id.
+ */
+export function createButton(
+  text: string,
+  className = "btn relative btn-secondary btn-small",
+  id?: string,
+): HTMLButtonElement {
+  const btn = document.createElement("button");
+  btn.className = className;
+  btn.textContent = text;
+  if (id) btn.id = id;
+  return btn;
+}
+
+/**
+ * Creates a generic action button used in the UI.
+ */
+export function createActionBtn(
+  id: string,
+  icon: string,
+  label: string,
+): HTMLDivElement {
+  const div = document.createElement("div");
+  div.id = id;
+  div.className = "gpt-action-btn";
+  div.textContent = icon;
+  div.setAttribute("data-label", label);
+  return div;
+}
+
+/**
+ * Creates a select element with provided options.
+ */
+export function createSelect(
+  id: string,
+  options: Array<[string, string]>,
+): HTMLSelectElement {
+  const select = document.createElement("select");
+  select.id = id;
+  options.forEach(([value, label]) => {
+    const opt = document.createElement("option");
+    opt.value = value;
+    opt.textContent = label;
+    select.appendChild(opt);
+  });
+  return select;
+}
+
+/**
+ * Creates a checkbox input wrapped in a label.
+ */
+export function createCheckbox(
+  id: string,
+  labelText: string,
+): HTMLLabelElement {
+  const label = document.createElement("label");
+  const input = document.createElement("input");
+  input.type = "checkbox";
+  input.id = id;
+  label.appendChild(input);
+  label.append(" " + labelText);
+  return label;
+}
+
+/**
+ * Makes a sidebar draggable and resizable, storing its position in options.
+ */
+export function makeSidebarInteractive(
+  el: HTMLElement,
+  prefix: string,
+  options: Record<string, any>,
+  saveOptions: (opts: any) => void,
+  observers: any[],
+): void {
+  const header = el.querySelector("div");
+  let dragging = false;
+  let startX = 0,
+    startY = 0,
+    startLeft = 0,
+    startTop = 0;
+
+  function savePos() {
+    const rect = el.getBoundingClientRect();
+    options[prefix + "X"] = rect.left;
+    options[prefix + "Y"] = rect.top;
+    options[prefix + "Width"] = rect.width;
+    options[prefix + "Height"] = rect.height;
+    saveOptions(options);
+  }
+
+  if (header) {
+    header.addEventListener("mousedown", (e) => {
+      dragging = true;
+      startX = e.clientX;
+      startY = e.clientY;
+      const rect = el.getBoundingClientRect();
+      startLeft = rect.left;
+      startTop = rect.top;
+      document.addEventListener("mousemove", onDrag);
+      document.addEventListener("mouseup", stopDrag);
+      e.preventDefault();
+    });
+  }
+
+  function onDrag(e: MouseEvent) {
+    if (!dragging) return;
+    const dx = e.clientX - startX;
+    const dy = e.clientY - startY;
+    el.style.left = startLeft + dx + "px";
+    el.style.top = startTop + dy + "px";
+  }
+
+  function stopDrag() {
+    if (!dragging) return;
+    dragging = false;
+    document.removeEventListener("mousemove", onDrag);
+    document.removeEventListener("mouseup", stopDrag);
+    savePos();
+  }
+
+  el.addEventListener("mouseup", () => savePos());
+
+  if (typeof ResizeObserver === "function") {
+    const ro = new ResizeObserver(() => {
+      function onResizeEnd() {
+        savePos();
+        el.removeEventListener("mouseup", onResizeEnd);
+        el.removeEventListener("mouseleave", onResizeEnd);
+      }
+      el.addEventListener("mouseup", onResizeEnd);
+      el.addEventListener("mouseleave", onResizeEnd);
+    });
+    ro.observe(el);
+    observers.push(ro);
+  }
+}
+
+/**
+ * Ensures the sidebar stays within the viewport bounds.
+ */
+export function ensureSidebarInBounds(
+  el: HTMLElement,
+  prefix: string,
+  options: Record<string, any>,
+  saveOptions: (opts: any) => void,
+): void {
+  const rect = el.getBoundingClientRect();
+  const margin = 10;
+  let left = rect.left;
+  let top = rect.top;
+  const maxX = window.innerWidth - rect.width - margin;
+  const maxY = window.innerHeight - rect.height - margin;
+  let changed = false;
+  if (left < margin) {
+    left = margin;
+    changed = true;
+  }
+  if (left > maxX) {
+    left = maxX;
+    changed = true;
+  }
+  if (top < margin) {
+    top = margin;
+    changed = true;
+  }
+  if (top > maxY) {
+    top = maxY;
+    changed = true;
+  }
+  if (changed) {
+    el.style.left = left + "px";
+    el.style.top = top + "px";
+    options[prefix + "X"] = left;
+    options[prefix + "Y"] = top;
+    saveOptions(options);
+  }
+}

--- a/tests/stats.test.ts
+++ b/tests/stats.test.ts
@@ -22,5 +22,6 @@ test("computes task stats correctly", { concurrency: false }, () => {
     closed: 1,
     inProgress: 2,
     fourX: 1,
+    total: 6,
   });
 });


### PR DESCRIPTION
## Summary
- split CI into separate lint, format, test, coverage, and build jobs
- extract reusable UI helpers and stats rendering with total and last-updated fields
- bump version to 1.0.55

## Testing
- `npm run lint`
- `npm run format`
- `npm test`
- `npm run coverage`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c1e96258048325834aff0f679af633