### PR TITLE
ci: update workflows and add auto release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,7 +66,7 @@ jobs:
           path: dist/openai-codex.user.js
 
   release:
-    needs: build
+    needs: [lint, format, test, coverage, build]
     if: github.event_name == 'push' && github.ref == 'refs/heads/main'
     permissions:
       contents: write


### PR DESCRIPTION
## Summary
- upgrade workflow actions to latest v4 versions
- add release job to CI using built artifact and tag from package version
- bump userscript version to 1.0.56
- require release job to wait for lint, format, test, coverage, and build jobs

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c1f0fdaffc8325addcf8c84573d4bf