### PR TITLE
ci: fix release step indentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,12 +80,12 @@ jobs:
         id: pkg
         run: |
           echo "version=$(node -p \"require('./package.json').version\")" >> $GITHUB_OUTPUT
-        - uses: actions/download-artifact@v4
-          with:
-            name: userscript
-            path: .
-        - uses: softprops/action-gh-release@v1
-          with:
-            tag_name: v${{ steps.pkg.outputs.version }}
-            name: v${{ steps.pkg.outputs.version }}
-            files: dist/openai-codex.user.js
+      - uses: actions/download-artifact@v4
+        with:
+          name: userscript
+          path: .
+      - uses: softprops/action-gh-release@v1
+        with:
+          tag_name: v${{ steps.pkg.outputs.version }}
+          name: v${{ steps.pkg.outputs.version }}
+          files: dist/openai-codex.user.js


### PR DESCRIPTION
## Summary
- realign download-artifact and action-gh-release steps in release job

## Testing
- `npm run build`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2a285de008325a225e4d7ee532a54